### PR TITLE
[마이프로필, 프로필 수정, 로그인, 온보딩, 앱설정 화면] 화면 UI 및 키보드 푸쉬 이벤트 처리 개선

### DIFF
--- a/NearTalk/NearTalk.xcodeproj/project.pbxproj
+++ b/NearTalk/NearTalk.xcodeproj/project.pbxproj
@@ -183,6 +183,9 @@
 		83649777292E15A50002DDE5 /* DummyAuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83649776292E15A50002DDE5 /* DummyAuthRepository.swift */; };
 		83649779292E1CA20002DDE5 /* DummyVerifyUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83649778292E1CA20002DDE5 /* DummyVerifyUseCase.swift */; };
 		8375F2232922B043004538AF /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8375F2222922B043004538AF /* OnboardingViewController.swift */; };
+		83808C0329371637002B78C0 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83808C0229371637002B78C0 /* OnboardingView.swift */; };
+		83808C0529371777002B78C0 /* OnboardingViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83808C0429371777002B78C0 /* OnboardingViewPreview.swift */; };
+		83808C0729372C08002B78C0 /* ProfileSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83808C0629372C08002B78C0 /* ProfileSettingView.swift */; };
 		8386B7CA292F59740095597D /* AppSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8386B7C9292F59740095597D /* AppSettingCoordinator.swift */; };
 		8386B7CC292F5D1C0095597D /* AppSettingDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8386B7CB292F5D1C0095597D /* AppSettingDIContainer.swift */; };
 		839D5BDD2922AD1000857FDD /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839D5BDC2922AD1000857FDD /* LoginViewController.swift */; };
@@ -424,6 +427,9 @@
 		83649778292E1CA20002DDE5 /* DummyVerifyUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyVerifyUseCase.swift; sourceTree = "<group>"; };
 		8367AB632922AF6300678669 /* ProfileSettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewController.swift; sourceTree = "<group>"; };
 		8375F2222922B043004538AF /* OnboardingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
+		83808C0229371637002B78C0 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		83808C0429371777002B78C0 /* OnboardingViewPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewPreview.swift; sourceTree = "<group>"; };
+		83808C0629372C08002B78C0 /* ProfileSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingView.swift; sourceTree = "<group>"; };
 		8386B7C9292F59740095597D /* AppSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingCoordinator.swift; sourceTree = "<group>"; };
 		8386B7CB292F5D1C0095597D /* AppSettingDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingDIContainer.swift; sourceTree = "<group>"; };
 		839D5BDC2922AD1000857FDD /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -1286,6 +1292,7 @@
 			isa = PBXGroup;
 			children = (
 				8367AB632922AF6300678669 /* ProfileSettingViewController.swift */,
+				83808C0629372C08002B78C0 /* ProfileSettingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1304,6 +1311,8 @@
 			isa = PBXGroup;
 			children = (
 				8375F2222922B043004538AF /* OnboardingViewController.swift */,
+				83808C0229371637002B78C0 /* OnboardingView.swift */,
+				83808C0429371777002B78C0 /* OnboardingViewPreview.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1750,6 +1759,7 @@
 				6001DA90292DBF770062EAD0 /* DefaultMediaRepository.swift in Sources */,
 				60FD706A2924080A00A4C29A /* ChatMessage.swift in Sources */,
 				555A6B2F29236D73001336ED /* FriendListViewModel.swift in Sources */,
+				83808C0529371777002B78C0 /* OnboardingViewPreview.swift in Sources */,
 				162B1B6C2935176D004724D9 /* NCMapRegion.swift in Sources */,
 				16530578291E18560026B815 /* UIViewPreview.swift in Sources */,
 				833062292924A3D7000E786E /* OnboardingDIContainer.swift in Sources */,
@@ -1773,6 +1783,7 @@
 				16530582291E19350026B815 /* ChatRoomListCoordinator.swift in Sources */,
 				60FD70622923927C00A4C29A /* NonceGenerator.swift in Sources */,
 				83D5ECD3292BF1F100AD1781 /* MyProfileDIContainer.swift in Sources */,
+				83808C0729372C08002B78C0 /* ProfileSettingView.swift in Sources */,
 				603FD395292A1E7000687ED4 /* LoginUseCase.swift in Sources */,
 				16530576291E17F70026B815 /* UIViewController+Preview.swift in Sources */,
 				83D5ECCE292BE81D00AD1781 /* MyProfileViewController.swift in Sources */,
@@ -1818,6 +1829,7 @@
 				16530580291E19250026B815 /* ChatRoomListViewModel.swift in Sources */,
 				603FD39329296B8500687ED4 /* DefaultProfileRepository.swift in Sources */,
 				60FD705D29238CBB00A4C29A /* RealTimeDatabaseService.swift in Sources */,
+				83808C0329371637002B78C0 /* OnboardingView.swift in Sources */,
 				7CA4EA3C292BE5FF00D8C757 /* ProfileDetailDIContainer.swift in Sources */,
 				5506CDDD292B4F810002F328 /* FetchFriendListUseCase.swift in Sources */,
 				83D5ECC5292B736500AD1781 /* DefaultAuthRepository.swift in Sources */,

--- a/NearTalk/NearTalk/Application/AppDelegate.swift
+++ b/NearTalk/NearTalk/Application/AppDelegate.swift
@@ -27,7 +27,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .current()
             .requestAuthorization(
                 options: authOptions,completionHandler: { (_, _) in
-                    application.registerForRemoteNotifications()
+                    DispatchQueue.main.async {
+                        application.registerForRemoteNotifications()
+                    }
                 }
             )
         return true

--- a/NearTalk/NearTalk/Application/AppDelegate.swift
+++ b/NearTalk/NearTalk/Application/AppDelegate.swift
@@ -26,9 +26,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UNUserNotificationCenter
             .current()
             .requestAuthorization(
-                options: authOptions,completionHandler: { (_, _) in
-                    DispatchQueue.main.async {
-                        application.registerForRemoteNotifications()
+                options: authOptions,completionHandler: { (result, error) in
+                    if let error {
+                        print(error)
+                        return
+                    }
+
+                    if result {
+                        DispatchQueue.main.async {
+                            application.registerForRemoteNotifications()
+                        }
                     }
                 }
             )

--- a/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingTableViewCell.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingTableViewCell.swift
@@ -13,12 +13,8 @@ final class AppSettingTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.addSubview(toggleSwitch)
+        self.accessoryView = toggleSwitch
         toggleSwitch.isUserInteractionEnabled = true
-        toggleSwitch.snp.makeConstraints { (make) in
-            make.trailing.equalToSuperview().inset(10)
-            make.centerY.equalToSuperview()
-        }
     }
     
     override func layoutSubviews() {
@@ -37,8 +33,4 @@ final class AppSettingTableViewCell: UITableViewCell {
     }
 
     static let identifier: String = String(describing: AppSettingTableViewCell.self)
-    
-//    var switchOnOff: ControlProperty<Bool> {
-//        self.toggleSwitch.rx.isOn
-//    }
 }

--- a/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingTableViewCell.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingTableViewCell.swift
@@ -9,12 +9,17 @@ import RxCocoa
 import UIKit
 
 final class AppSettingTableViewCell: UITableViewCell {
+    static let identifier: String = String(describing: AppSettingTableViewCell.self)
+    
     let toggleSwitch = UISwitch()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.accessoryView = toggleSwitch
-        toggleSwitch.isUserInteractionEnabled = true
+        self.configureToggleSwitch()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func layoutSubviews() {
@@ -22,15 +27,18 @@ final class AppSettingTableViewCell: UITableViewCell {
         super.layoutSubviews()
     }
     
+    private func configureToggleSwitch() {
+        self.addSubview(self.toggleSwitch)
+        toggleSwitch.isUserInteractionEnabled = true
+        toggleSwitch.snp.makeConstraints { (make) in
+            make.trailing.equalToSuperview().inset(10)
+            make.centerY.equalToSuperview()
+        }
+    }
+    
     func setUpCell(text: String) {
         var configuration = self.defaultContentConfiguration()
         configuration.text = text
         self.contentConfiguration = configuration
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    static let identifier: String = String(describing: AppSettingTableViewCell.self)
 }

--- a/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingViewController.swift
@@ -53,7 +53,25 @@ final class AppSettingViewController: UIViewController, UITableViewDelegate {
     override func viewDidLayoutSubviews() {
         self.viewModel.viewWillAppear()
         super.viewDidLayoutSubviews()
+        tableView.snp.remakeConstraints { (make) in
+            make.horizontalEdges.equalToSuperview().inset(15)
+            make.top.equalToSuperview().inset(30)
+            make.height.equalTo(self.tableView.visibleCells.reduce(0, { partialResult, cell in
+                partialResult + cell.frame.height
+            }))
+        }
     }
+    
+//    override func viewDidAppear(_ animated: Bool) {
+//        tableView.snp.remakeConstraints { (make) in
+//            make.horizontalEdges.equalToSuperview().inset(15)
+//            make.top.equalToSuperview().inset(30)
+//            make.height.equalTo(self.tableView.visibleCells.reduce(0, { partialResult, cell in
+//                partialResult + cell.frame.height
+//            }))
+//        }
+//        super.viewDidAppear(animated)
+//    }
     
     override func viewWillAppear(_ animated: Bool) {
         self.viewModel.viewWillAppear()
@@ -97,6 +115,7 @@ private extension AppSettingViewController {
         tableView.register(AppSettingTableViewCell.self, forCellReuseIdentifier: AppSettingTableViewCell.identifier)
         tableView.dataSource = self.dataSource
         tableView.separatorInset = .zero
+        tableView.layer.cornerRadius = 5.0
         self.tableView.isScrollEnabled = false
     }
     

--- a/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingViewController.swift
@@ -96,7 +96,7 @@ private extension AppSettingViewController {
         tableView.delegate = self
         tableView.register(AppSettingTableViewCell.self, forCellReuseIdentifier: AppSettingTableViewCell.identifier)
         tableView.dataSource = self.dataSource
-        self.tableView.backgroundColor = .systemBackground
+        tableView.separatorInset = .zero
         self.tableView.isScrollEnabled = false
     }
     

--- a/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/View/AppSettingViewController.swift
@@ -79,10 +79,7 @@ final class AppSettingViewController: UIViewController, UITableViewDelegate {
 
 private extension AppSettingViewController {
     func configureUI() {
-        navigationController?.navigationBar.isTranslucent = false
-        navigationController?.navigationBar.backgroundColor = .systemGray5
         navigationItem.title = "앱 설정"
-        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16, weight: .bold)]
         view.addSubview(tableView)
         view.backgroundColor = .systemBackground
     }

--- a/NearTalk/NearTalk/Presentation/AppSetting/ViewModel/AppSettingViewModel.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/ViewModel/AppSettingViewModel.swift
@@ -104,9 +104,9 @@ final class DefaultAppSettingViewModel: AppSettingViewModel {
         if on {
             self.requestNotificationAuthorization()
         } else {
-            UIApplication.shared.unregisterForRemoteNotifications()
-//            UIApplication.shared.unregisterForRemoteNotifications()
-//            UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+            DispatchQueue.main.async {
+                UIApplication.shared.unregisterForRemoteNotifications()
+            }
             self.notificationOnOff.accept(false)
             UserDefaults.standard.set(false, forKey: DefaultAppSettingViewModel.appNotificationOnOffKey)
         }
@@ -123,9 +123,9 @@ final class DefaultAppSettingViewModel: AppSettingViewModel {
                     UIApplication.shared.registerForRemoteNotifications()
                 }
             } else {
-                UIApplication.shared.unregisterForRemoteNotifications()
-//                UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
-//                UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+                DispatchQueue.main.async {
+                    UIApplication.shared.unregisterForRemoteNotifications()
+                }
                 self?.notificationOnOff.accept(false)
                 UserDefaults.standard.set(false, forKey: DefaultAppSettingViewModel.appNotificationOnOffKey)
             }

--- a/NearTalk/NearTalk/Presentation/AppSetting/ViewModel/AppSettingViewModel.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/ViewModel/AppSettingViewModel.swift
@@ -119,7 +119,9 @@ final class DefaultAppSettingViewModel: AppSettingViewModel {
         result.subscribe { [weak self] accepted in
             if accepted {
                 self?.refreshNotificationAuthorization()
-                UIApplication.shared.registerForRemoteNotifications()
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
             } else {
                 UIApplication.shared.unregisterForRemoteNotifications()
 //                UNUserNotificationCenter.current().removeAllPendingNotificationRequests()

--- a/NearTalk/NearTalk/Presentation/Login/View/LoginViewController.swift
+++ b/NearTalk/NearTalk/Presentation/Login/View/LoginViewController.swift
@@ -42,15 +42,14 @@ private extension LoginViewController {
     }
     func configureConstraint() {
         self.logoView.snp.makeConstraints { (make) in
-            make.top.equalToSuperview().offset(30)
-            make.height.width.equalTo(60)
-            make.centerX.equalToSuperview()
+            make.height.width.equalTo(240)
+            make.center.equalToSuperview()
         }
         
         self.loginButton.snp.makeConstraints { (make) in
-            make.horizontalEdges.equalToSuperview().inset(30)
-            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(10)
-            make.height.equalTo(loginButton.snp.width).multipliedBy(0.1)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(30)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            make.height.equalTo(loginButton.snp.width).multipliedBy(0.15)
         }
     }
     

--- a/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
+++ b/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
@@ -144,10 +144,8 @@ private extension MyProfileViewController {
     }
     
     func configureNavigationBar() {
-//        navigationController?.navigationBar.backgroundColor = .systemGray5
         navigationController?.navigationBar.isTranslucent = false
         navigationItem.title = "내 프로필"
-//        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16, weight: .bold)]
     }
     
     func setTableView() {

--- a/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
+++ b/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
@@ -18,7 +18,6 @@ final class MyProfileViewController: UIViewController, UITableViewDelegate {
     private let profileImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
         $0.isUserInteractionEnabled = true
-        $0.backgroundColor = .lightGray
     }
     
     private let fieldStack = UIStackView().then {
@@ -67,11 +66,16 @@ final class MyProfileViewController: UIViewController, UITableViewDelegate {
         self.bindViewModel()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        self.profileImageView.makeRounded()
+    override func viewWillLayoutSubviews() {
         configureTableView()
-        super.viewWillAppear(animated)
+        self.profileImageView.makeRounded()
+        super.viewWillLayoutSubviews()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+//        self.profileImageView.makeRounded()
         self.viewModel.viewWillAppear()
+        super.viewWillAppear(animated)
     }
     
     init(viewModel: any MyProfileViewModel) {
@@ -118,6 +122,7 @@ private extension MyProfileViewController {
         self.tableView.layer.cornerRadius = 5.0
         self.tableView.layer.masksToBounds = true
         self.tableView.clipsToBounds = true
+        self.tableView.separatorInset = .zero
     }
     
     func configureConstraint() {
@@ -172,7 +177,15 @@ private extension MyProfileViewController {
             .compactMap { $0 }
             .compactMap { URL(string: $0) }
             .bind(onNext: { url in
+                self.profileImageView.backgroundColor = .clear
                 self.profileImageView.kf.setImage(with: url)
+            })
+            .disposed(by: self.disposeBag)
+        self.viewModel.image
+            .filter { $0 == nil }
+            .bind(onNext: { _ in
+                self.profileImageView.backgroundColor = .lightGray
+                self.profileImageView.image = nil
             })
             .disposed(by: self.disposeBag)
     }

--- a/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
+++ b/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
@@ -72,6 +72,17 @@ final class MyProfileViewController: UIViewController, UITableViewDelegate {
         super.viewWillLayoutSubviews()
     }
     
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.snp.remakeConstraints { (make) in
+            make.top.equalTo(myProfileView.snp.bottom).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(10)
+            make.height.equalTo(self.tableView.visibleCells.reduce(0, { partialResult, cell in
+                partialResult + cell.frame.height
+            }))
+        }
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
 //        self.profileImageView.makeRounded()
         self.viewModel.viewWillAppear()

--- a/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
+++ b/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
@@ -26,16 +26,28 @@ final class MyProfileViewController: UIViewController, UITableViewDelegate {
         $0.axis = .vertical
     }
     
+    private let nicknameTitleLabel: UILabel = UILabel().then { label in
+        label.textAlignment = .natural
+        label.text = "닉네임"
+        label.font = UIFont.systemFont(ofSize: 16, weight: .bold)
+    }
+    
     private let nicknameLabel = UILabel().then {
         $0.textAlignment = .natural
         $0.text = "닉네임"
-        $0.font = UIFont.systemFont(ofSize: 30)
+        $0.font = UIFont.systemFont(ofSize: 24, weight: .regular)
+    }
+    
+    private let messageTitleLabel: UILabel = UILabel().then { label in
+        label.textAlignment = .natural
+        label.text = "상태 메세지"
+        label.font = UIFont.systemFont(ofSize: 16, weight: .bold)
     }
     
     private let messageLabel = UILabel().then {
         $0.textAlignment = .natural
         $0.text = "상태 메세지"
-        $0.font = UIFont.systemFont(ofSize: 30)
+        $0.font = UIFont.systemFont(ofSize: 24)
     }
     
     private let tableView: UITableView = UITableView()
@@ -125,7 +137,9 @@ private extension MyProfileViewController {
         
         myProfileView.addSubview(profileImageView)
         myProfileView.addSubview(fieldStack)
+        fieldStack.addArrangedSubview(nicknameTitleLabel)
         fieldStack.addArrangedSubview(nicknameLabel)
+        fieldStack.addArrangedSubview(messageTitleLabel)
         fieldStack.addArrangedSubview(messageLabel)
     }
     

--- a/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
+++ b/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
@@ -144,10 +144,10 @@ private extension MyProfileViewController {
     }
     
     func configureNavigationBar() {
-        navigationController?.navigationBar.backgroundColor = .systemGray5
+//        navigationController?.navigationBar.backgroundColor = .systemGray5
         navigationController?.navigationBar.isTranslucent = false
         navigationItem.title = "내 프로필"
-        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16, weight: .bold)]
+//        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16, weight: .bold)]
     }
     
     func setTableView() {

--- a/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingView.swift
+++ b/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingView.swift
@@ -1,0 +1,152 @@
+//
+//  OnboardingView.swift
+//  NearTalk
+//
+//  Created by Preston Kim on 2022/11/30.
+//
+
+import RxCocoa
+import RxGesture
+import RxSwift
+import SnapKit
+import UIKit
+
+final class OnboardingView: UIView {
+    // MARK: - UI properties
+    private let logoView = UIImageView(image: UIImage(systemName: "map.circle.fill"))
+    private let profileImageView: UIImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.isUserInteractionEnabled = true
+        $0.backgroundColor = .lightGray
+    }
+
+    private let nicknameField: UITextField = UITextField().then {
+        $0.placeholder = "닉네임"
+        $0.font = UIFont.systemFont(ofSize: 30)
+    }
+    
+    private let messageField: UITextField = UITextField().then {
+        $0.placeholder = "상태 메세지"
+        $0.font = UIFont.systemFont(ofSize: 30)
+    }
+    
+    private let registerButton: UIButton = UIButton().then {
+        $0.layer.cornerRadius = 5
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .systemBlue
+        $0.isEnabled = false
+        $0.setTitle("등록하기", for: .normal)
+        $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        $0.frame = CGRect(origin: .zero, size: $0.intrinsicContentSize)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.addSubViews()
+        self.configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension OnboardingView {
+    var nickNameText: Observable<String> {
+        self.nicknameField.rx.text
+            .orEmpty
+            .asObservable()
+    }
+    
+    var messageText: Observable<String> {
+        self.messageField.rx.text
+            .orEmpty
+            .asObservable()
+    }
+    
+    var tapProfileEvent: ControlEvent<Void> {
+        return ControlEvent(
+            events: self.profileImageView.rx
+                .tapGesture()
+                .when(.ended)
+                .map { _ in () })
+    }
+    
+    var registerBtnClickEvent: ControlEvent<Void> {
+        return self.registerButton.rx
+            .controlEvent(.touchUpInside)
+    }
+    
+    var profileImage: AnyObserver<UIImage?> {
+        return self.profileImageView.rx.image
+            .asObserver()
+    }
+    
+    var registerEnable: AnyObserver<Bool> {
+        return self.registerButton.rx
+            .isEnabled
+            .asObserver()
+    }
+}
+
+extension OnboardingView {
+    func makeProfileViewRounded() {
+        self.profileImageView.makeRounded()
+    }
+}
+
+private extension OnboardingView {
+    func addSubViews() {
+        [logoView, profileImageView, nicknameField, messageField, registerButton].forEach {
+            self.addSubview($0)
+        }
+    }
+    
+    func configureConstraints() {
+        self.configureLogoView()
+        self.configureProfileImageView()
+        self.configureNickNameField()
+        self.configureMessageField()
+        self.configureRegisterButton()
+    }
+    
+    func configureLogoView() {
+        logoView.snp.makeConstraints { (make) in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(30)
+            make.width.height.equalTo(120)
+        }
+    }
+    
+    func configureProfileImageView() {
+        profileImageView.snp.makeConstraints { (make) in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(logoView.snp.bottom).offset(30)
+            make.width.height.equalTo(160)
+        }
+    }
+    
+    func configureNickNameField() {
+        nicknameField.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.top.equalTo(profileImageView.snp.bottom).offset(30)
+            make.height.equalTo(nicknameField.snp.width).multipliedBy(0.15)
+        }
+    }
+    
+    func configureMessageField() {
+        messageField.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.top.equalTo(nicknameField.snp.bottom).offset(30)
+            make.height.equalTo(messageField.snp.width).multipliedBy(0.15)
+        }
+    }
+    
+    func configureRegisterButton() {
+        registerButton.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.bottom.equalTo(self.safeAreaLayoutGuide).inset(30)
+            make.top.greaterThanOrEqualToSuperview().offset(30)
+        }
+    }
+}

--- a/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingViewController.swift
@@ -12,10 +12,13 @@ import UIKit
 
 final class OnboardingViewController: UIViewController {
     // MARK: - UI properties
-    private lazy var rootView: OnboardingView = OnboardingView()
+    private let rootView: OnboardingView = OnboardingView()
+    private let scrollView: UIScrollView = UIScrollView().then {
+        $0.keyboardDismissMode = .onDrag
+        $0.bounces = false
+    }
     
     // MARK: - Properties
-    private var buttonToggle: Bool = false
     private let disposeBag: DisposeBag = DisposeBag()
     private let viewModel: any OnboardingViewModel
     
@@ -30,18 +33,31 @@ final class OnboardingViewController: UIViewController {
     }
     
     override func loadView() {
-        self.view = rootView
+        self.view = self.scrollView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.scrollView.addSubview(self.rootView)
         self.view.backgroundColor = .white
         self.bindToViewModel()
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
+    override func viewWillLayoutSubviews() {
+        self.rootView.makeProfileViewRounded()
+        super.viewWillLayoutSubviews()
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        self.rootView.makeProfileViewRounded()
+        self.scrollView.contentSize = .init(width: self.view.frame.width, height: self.rootView.height)
+        self.rootView.frame = .init(origin: .zero, size: self.scrollView.contentSize)
+        self.rootView.snp.makeConstraints { make in
+            make.edges.equalTo(self.scrollView.contentLayoutGuide)
+            make.width.equalToSuperview()
+            make.height.equalTo(self.scrollView.contentSize.height)
+        }
     }
 }
 
@@ -49,7 +65,7 @@ final class OnboardingViewController: UIViewController {
 private extension OnboardingViewController {
     func bindToViewModel() {
         self.bindNickNameField()
-        self.bindMessageFeild()
+        self.bindMessageField()
         self.bindProfileTap()
         self.bindRegisterButton()
     }
@@ -60,13 +76,57 @@ private extension OnboardingViewController {
                 self?.viewModel.editNickName(text)
             })
             .disposed(by: self.disposeBag)
+        self.viewModel.nickNameValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? "사용 가능한 닉네임 입니다" : "5-16 자 사이의 영어 소문자, 숫자, -_ 기호만 사용하십시오"
+            }
+            .drive(self.rootView.nickNameValidityMessage)
+            .disposed(by: self.disposeBag)
+        self.viewModel.nickNameValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? UIColor.green : UIColor.red
+            }
+            .drive(self.rootView.nickNameValidityColor)
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillShowOnNickNameField
+            .compactMap { self.keyboardNotificationHandler($0) }
+            .drive(onNext: { self.moveKeyboardUp(keyboardHeight: $0) })
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillDismissFromNickNameField
+            .filter { self.keyboardNotificationHandler($0) != nil }
+            .drive(onNext: { _ in self.moveKeyboardDown() })
+            .disposed(by: self.disposeBag)
     }
     
-    func bindMessageFeild() {
+    func bindMessageField() {
         self.rootView.messageText
             .bind(onNext: { [weak self] text in
                 self?.viewModel.editStatusMessage(text)
             })
+            .disposed(by: self.disposeBag)
+        self.viewModel.messageValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? "사용 가능한 메세지 입니다" : "50자 이하로 작성하십시오"
+            }
+            .drive(self.rootView.messageValidityMessage)
+            .disposed(by: self.disposeBag)
+        self.viewModel.messageValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? UIColor.green : UIColor.red
+            }
+            .drive(self.rootView.messageValidityColor)
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillShowOnMessageField
+            .compactMap { self.keyboardNotificationHandler($0) }
+            .drive(onNext: { self.moveKeyboardUp(keyboardHeight: $0) })
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillDismissFromMessageField
+            .filter { self.keyboardNotificationHandler($0) != nil }
+            .drive(onNext: { _ in self.moveKeyboardDown() })
             .disposed(by: self.disposeBag)
     }
     
@@ -94,5 +154,26 @@ private extension OnboardingViewController {
                 self?.viewModel.register()
             })
             .disposed(by: self.disposeBag)
+    }
+}
+
+private extension OnboardingViewController {
+    func moveKeyboardUp(keyboardHeight: CGFloat) {
+        self.scrollToUp(keyboardHeight: keyboardHeight)
+    }
+    
+    func moveKeyboardDown() {
+        self.scrollToDown()
+    }
+    
+    func scrollToUp(keyboardHeight: CGFloat) {
+        let inset: UIEdgeInsets = .init(top: 0, left: 0, bottom: keyboardHeight, right: 0)
+        self.scrollView.contentInset = inset
+        self.scrollView.scrollIndicatorInsets = inset
+    }
+    
+    func scrollToDown() {
+        self.scrollView.contentInset = .zero
+        self.scrollView.scrollIndicatorInsets = .zero
     }
 }

--- a/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingViewController.swift
@@ -6,43 +6,13 @@
 //
 
 import RxCocoa
-import RxGesture
 import RxSwift
 import SnapKit
-import Then
 import UIKit
 
 final class OnboardingViewController: UIViewController {
     // MARK: - UI properties
-    private let logoView = UIImageView(image: UIImage(systemName: "map.circle.fill"))
-    private let profileImageView: UIImageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFill
-        $0.isUserInteractionEnabled = true
-        $0.backgroundColor = .lightGray
-    }
-
-    private let nicknameField: UITextField = UITextField().then {
-        $0.placeholder = "닉네임"
-        $0.font = UIFont.systemFont(ofSize: 30)
-    }
-    
-    private let messageField: UITextField = UITextField().then {
-        $0.placeholder = "상태 메세지"
-        $0.font = UIFont.systemFont(ofSize: 30)
-    }
-    
-    private let registerButton: UIButton = UIButton().then {
-        $0.layer.cornerRadius = 5
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .systemBlue
-        $0.isEnabled = false
-        $0.setTitle("등록하기", for: .normal)
-    }
-    
-    private lazy var scrollView = UIScrollView().then {
-        $0.showsHorizontalScrollIndicator = false
-        $0.delegate = self
-    }
+    private lazy var rootView: OnboardingView = OnboardingView()
     
     // MARK: - Properties
     private var buttonToggle: Bool = false
@@ -59,84 +29,24 @@ final class OnboardingViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func loadView() {
+        self.view = rootView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
-        self.addSubViews()
-        self.configureConstraints()
         self.bindToViewModel()
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        self.profileImageView.makeRounded()
+        self.rootView.makeProfileViewRounded()
     }
 }
 
 // MARK: - Helpers
 private extension OnboardingViewController {
-    func addSubViews() {
-        [logoView, profileImageView, nicknameField, messageField, registerButton].forEach {
-            scrollView.addSubview($0)
-        }
-        view.addSubview(scrollView)
-    }
-    
-    func configureConstraints() {
-        self.configureScrollView()
-        self.configureLogoView()
-        self.configureProfileImageView()
-        self.configureNickNameField()
-        self.configureMessageField()
-        self.configureRegisterButton()
-    }
-    
-    func configureScrollView() {
-        scrollView.snp.makeConstraints { (make) in
-            make.edges.width.equalToSuperview()
-        }
-    }
-    
-    func configureLogoView() {
-        logoView.snp.makeConstraints { (make) in
-            make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(30)
-            make.width.height.equalTo(120)
-        }
-    }
-    
-    func configureProfileImageView() {
-        profileImageView.snp.makeConstraints { (make) in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(logoView.snp.bottom).offset(30)
-            make.width.height.equalTo(120)
-        }
-    }
-    
-    func configureNickNameField() {
-        nicknameField.snp.makeConstraints { (make) in
-            make.horizontalEdges.equalToSuperview().inset(20)
-            make.top.equalTo(profileImageView.snp.bottom).offset(30)
-            make.height.equalTo(nicknameField.snp.width).multipliedBy(0.15)
-        }
-    }
-    
-    func configureMessageField() {
-        messageField.snp.makeConstraints { (make) in
-            make.horizontalEdges.equalToSuperview().inset(20)
-            make.top.equalTo(nicknameField.snp.bottom).offset(30)
-            make.height.equalTo(messageField.snp.width).multipliedBy(0.15)
-        }
-    }
-    
-    func configureRegisterButton() {
-        registerButton.snp.makeConstraints { (make) in
-            make.horizontalEdges.equalToSuperview().inset(20)
-            make.top.equalTo(messageField.snp.bottom).offset(30)
-            make.height.equalTo(registerButton.snp.width).multipliedBy(0.1)
-        }
-    }
-    
     func bindToViewModel() {
         self.bindNickNameField()
         self.bindMessageFeild()
@@ -145,18 +55,15 @@ private extension OnboardingViewController {
     }
     
     func bindNickNameField() {
-        self.nicknameField.rx.value
-            .orEmpty
+        self.rootView.nickNameText
             .bind(onNext: { [weak self] text in
                 self?.viewModel.editNickName(text)
-                
             })
             .disposed(by: self.disposeBag)
     }
     
     func bindMessageFeild() {
-        self.messageField.rx.value
-            .orEmpty
+        self.rootView.messageText
             .bind(onNext: { [weak self] text in
                 self?.viewModel.editStatusMessage(text)
             })
@@ -164,37 +71,28 @@ private extension OnboardingViewController {
     }
     
     func bindProfileTap() {
-        self.profileImageView.rx
-            .tapGesture()
-            .bind(onNext: { [weak self] gesture in
-                if gesture.state == .ended {
-                    self?.viewModel.editImage()
-                }
+        self.rootView.tapProfileEvent
+            .bind(onNext: { [weak self] _ in
+                self?.viewModel.editImage()
             })
             .disposed(by: self.disposeBag)
         self.viewModel.image
-            .asObservable()
+            .asDriver()
             .compactMap { $0 }
             .map { UIImage(data: $0) }
-            .bind(onNext: { self.profileImageView.image = $0 })
+            .drive(self.rootView.profileImage)
             .disposed(by: self.disposeBag)
     }
     
     func bindRegisterButton() {
         self.viewModel.registerEnable
-            .bind(to: self.registerButton.rx.isEnabled)
+            .asDriver()
+            .drive(self.rootView.registerEnable)
             .disposed(by: self.disposeBag)
-        self.registerButton.rx
-            .tap
-            .bind(onNext: { [weak self] in
+        self.rootView.registerBtnClickEvent
+            .bind(onNext: { [weak self] _ in
                 self?.viewModel.register()
             })
             .disposed(by: self.disposeBag)
-    }
-}
-
-extension OnboardingViewController: UIScrollViewDelegate {
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollView.contentOffset.x = 0
     }
 }

--- a/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingViewPreview.swift
+++ b/NearTalk/NearTalk/Presentation/Onboarding/View/OnboardingViewPreview.swift
@@ -1,0 +1,20 @@
+//
+//  OnboardingViewPreview.swift
+//  NearTalk
+//
+//  Created by Preston Kim on 2022/11/30.
+//
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct OnboardingViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        let appDIContainer: AppDIContainer = AppDIContainer(navigationController: UINavigationController(), launchScreenActions: .init(), loginAction: .init(), showMainViewController: nil)
+        let diContainer: DefaultOnboardingDIContainer = appDIContainer.resolveOnboardingDIContainer()
+        let viewController: OnboardingViewController = diContainer.resolveOnboardingViewController()
+        viewController.showPreview(.iPhoneSE3)
+    }
+}
+
+#endif

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
@@ -11,6 +11,8 @@ import RxSwift
 import SnapKit
 import UIKit
 
+typealias KeyboardShowValues = (frame: CGRect, curve: Int, duration: Double)
+
 final class ProfileSettingView: UIView {
     // MARK: - UI properties
     private let profileImageView: UIImageView = UIImageView().then {
@@ -19,14 +21,34 @@ final class ProfileSettingView: UIView {
         $0.backgroundColor = .lightGray
     }
 
+    private let nickNameLabel: UILabel = UILabel().then {
+        $0.text = "닉네임"
+    }
+    
+    private let nickNameValidityMessageLabel: UILabel = UILabel().then {
+        $0.text = ""
+    }
+    
+    private let messageValidityMessageLabel: UILabel = UILabel().then {
+        $0.text = ""
+    }
+    
+    private let messageLabel: UILabel = UILabel().then {
+        $0.text = "상태메세지"
+    }
+    
     private let nicknameField: UITextField = UITextField().then {
         $0.placeholder = "닉네임"
-        $0.font = UIFont.systemFont(ofSize: 30)
+        $0.borderStyle = .roundedRect
+        $0.autocapitalizationType = .none
+        $0.clearButtonMode = .always
     }
     
     private let messageField: UITextField = UITextField().then {
         $0.placeholder = "상태 메세지"
-        $0.font = UIFont.systemFont(ofSize: 30)
+        $0.borderStyle = .roundedRect
+        $0.autocapitalizationType = .none
+        $0.clearButtonMode = .always
     }
     
     override init(frame: CGRect) {
@@ -48,7 +70,7 @@ final class ProfileSettingView: UIView {
     }
 }
 
-extension ProfileSettingView {
+extension ProfileSettingView {    
     var nickNameText: Observable<String> {
         self.nicknameField.rx.text
             .orEmpty
@@ -73,19 +95,166 @@ extension ProfileSettingView {
         return self.profileImageView.rx.image
             .asObserver()
     }
+    
+    private var keyboardWillShow: ControlEvent<Notification> {
+        return ControlEvent(events: NotificationCenter.default.rx
+            .notification(UIResponder.keyboardWillShowNotification))
+    }
+    
+    private var keyboardWillHide: ControlEvent<Notification> {
+        return ControlEvent(events: NotificationCenter.default.rx
+            .notification(UIResponder.keyboardWillHideNotification))
+    }
+    
+    var keyboardWillShowOnNickNameField: Driver<Notification> {
+        return self.keyboardWillShow.asDriver()
+            .filter { _ in
+                self.nicknameField.isFirstResponder
+            }
+    }
+    
+    var keyboardWillDismissFromNickNameField: Driver<Notification> {
+        return self.keyboardWillHide.asDriver()
+            .filter { _ in
+                self.nicknameField.isFirstResponder
+            }
+    }
+    
+    var keyboardWillShowOnMessageField: Driver<Notification> {
+        return self.keyboardWillShow.asDriver()
+            .filter { _ in
+                self.messageField.isFirstResponder
+            }
+    }
+    
+    var keyboardWillDismissFromMessageField: Driver<Notification> {
+        return self.keyboardWillHide.asDriver()
+            .filter { _ in
+                self.messageField.isFirstResponder
+            }
+    }
+    
+    func moveUpKeyboardAboveNickName(userInfo: [AnyHashable: Any]) {
+        print(#function)
+        
+        guard let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let keyboardAnimationCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
+              let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+              let keyboardCurve = UIView.AnimationCurve(rawValue: keyboardAnimationCurve)
+        else {
+            return
+        }
+        
+        let keyboardSize: CGRect = keyboardFrame
+        let keyboardHeight: CGFloat = keyboardSize.height
+        
+        let newConstant = keyboardHeight - (self.frame.height - self.profileImageView.frame.height - self.nickNameLabel.frame.height - self.nicknameField.frame.height - self.nickNameValidityMessageLabel.frame.height - 50)
+        
+        self.profileImageView.snp.remakeConstraints { make in
+            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+            make.height.equalTo(profileImageView.snp.width)
+            make.top.equalTo(self.safeAreaLayoutGuide).offset(-newConstant)
+        }
+        
+        self.messageLabel.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
+            make.top.equalTo(nickNameValidityMessageLabel.snp.bottom).offset(30 + keyboardHeight)
+        }
+        
+        let animator = UIViewPropertyAnimator(duration: keyboardDuration, curve: keyboardCurve) { [weak self] in
+            self?.layoutIfNeeded()
+        }
+        
+        animator.startAnimation()
+    }
+    
+    func moveUpKeyboardAboveMessage(userInfo: [AnyHashable: Any]) {
+        print(#function)
+        
+        guard let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let keyboardAnimationCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
+              let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+              let keyboardCurve = UIView.AnimationCurve(rawValue: keyboardAnimationCurve)
+        else {
+            return
+        }
+        
+        let keyboardSize: CGRect = keyboardFrame
+        let keyboardHeight: CGFloat = keyboardSize.height
+        let newConstant = keyboardHeight
+        
+        self.profileImageView.snp.remakeConstraints { make in
+            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+            make.height.equalTo(profileImageView.snp.width)
+            make.top.equalTo(self.safeAreaLayoutGuide).offset(-newConstant)
+        }
+        
+        let animator = UIViewPropertyAnimator(duration: keyboardDuration, curve: keyboardCurve) { [weak self] in
+            self?.layoutIfNeeded()
+        }
+        
+        animator.startAnimation()
+    }
+
+    func moveDownKeyboard(userInfo: [AnyHashable: Any]) {
+        print(#function)
+        self.endEditing(true)
+        guard let keyboardAnimationCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
+              let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+              let keyboardCurve = UIView.AnimationCurve(rawValue: keyboardAnimationCurve)
+        else {
+            return
+        }
+        
+        self.profileImageView.snp.remakeConstraints { make in
+            make.horizontalEdges.top.equalTo(self.safeAreaLayoutGuide)
+            make.height.equalTo(profileImageView.snp.width)
+        }
+
+        self.messageLabel.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
+            make.top.equalTo(nickNameValidityMessageLabel.snp.bottom).offset(30)
+        }
+        
+        let animator = UIViewPropertyAnimator(duration: keyboardDuration, curve: keyboardCurve) { [weak self] in
+            self?.layoutIfNeeded()
+        }
+        
+        animator.startAnimation()
+    }
+    
+    var nickNameValidityMessage: AnyObserver<String?> {
+        self.nickNameValidityMessageLabel.rx.text
+            .asObserver()
+    }
+    
+    var nickNameValidityColor: AnyObserver<UIColor> {
+        self.nickNameValidityMessageLabel.rx.textColor
+            .asObserver()
+    }
+    
+    var messageValidityMessage: AnyObserver<String?> {
+        self.messageValidityMessageLabel.rx.text
+            .asObserver()
+    }
+    
+    var messageValidityColor: AnyObserver<UIColor> {
+        self.messageValidityMessageLabel.rx.textColor
+            .asObserver()
+    }
 }
 
 private extension ProfileSettingView {
     func addSubViews() {
-        [profileImageView, nicknameField, messageField].forEach {
+        [profileImageView, nickNameLabel, nicknameField, nickNameValidityMessageLabel, messageLabel, messageField, messageValidityMessageLabel].forEach {
             self.addSubview($0)
         }
     }
     
     func configureConstraints() {
         self.configureProfileImageView()
-        self.configureNickNameField()
-        self.configureMessageField()
+        self.configureNickNameSection()
+        self.configureMessageSection()
     }
     
     func configureProfileImageView() {
@@ -95,19 +264,39 @@ private extension ProfileSettingView {
         }
     }
     
-    func configureNickNameField() {
-        nicknameField.snp.makeConstraints { (make) in
+    func configureNickNameSection() {
+        nickNameLabel.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
-            make.top.equalTo(profileImageView.snp.bottom).offset(30)
+            make.top.equalTo(self.profileImageView.snp.bottom).offset(30)
+        }
+        
+        nicknameField.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalTo(nickNameLabel)
+            make.top.equalTo(nickNameLabel.snp.bottom).offset(10)
             make.height.equalTo(nicknameField.snp.width).multipliedBy(0.15)
+        }
+        
+        nickNameValidityMessageLabel.snp.makeConstraints { make in
+            make.horizontalEdges.equalTo(nickNameLabel)
+            make.top.equalTo(nicknameField.snp.bottom).offset(10)
         }
     }
     
-    func configureMessageField() {
-        messageField.snp.makeConstraints { (make) in
+    func configureMessageSection() {
+        messageLabel.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
-            make.top.equalTo(nicknameField.snp.bottom).offset(30)
+            make.top.equalTo(self.nickNameValidityMessageLabel.snp.bottom).offset(30)
+        }
+        
+        messageField.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalTo(messageLabel)
+            make.top.equalTo(messageLabel.snp.bottom).offset(10)
             make.height.equalTo(messageField.snp.width).multipliedBy(0.15)
+        }
+        
+        messageValidityMessageLabel.snp.makeConstraints { make in
+            make.horizontalEdges.equalTo(messageLabel)
+            make.top.equalTo(messageField.snp.bottom).offset(10)
         }
     }
 }

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
@@ -1,0 +1,113 @@
+//
+//  ProfileSettingView.swift
+//  NearTalk
+//
+//  Created by Preston Kim on 2022/11/30.
+//
+
+import RxCocoa
+import RxGesture
+import RxSwift
+import SnapKit
+import UIKit
+
+final class ProfileSettingView: UIView {
+    // MARK: - UI properties
+    private let profileImageView: UIImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.isUserInteractionEnabled = true
+        $0.backgroundColor = .lightGray
+    }
+
+    private let nicknameField: UITextField = UITextField().then {
+        $0.placeholder = "닉네임"
+        $0.font = UIFont.systemFont(ofSize: 30)
+    }
+    
+    private let messageField: UITextField = UITextField().then {
+        $0.placeholder = "상태 메세지"
+        $0.font = UIFont.systemFont(ofSize: 30)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.addSubViews()
+        self.configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func injectProfileData(profileData: NecessaryProfileComponent) {
+        self.nicknameField.text = profileData.nickName
+        self.messageField.text = profileData.message
+        if let imageData = profileData.image {
+            self.profileImageView.image = UIImage(data: imageData)
+        }
+    }
+}
+
+extension ProfileSettingView {
+    var nickNameText: Observable<String> {
+        self.nicknameField.rx.text
+            .orEmpty
+            .asObservable()
+    }
+    
+    var messageText: Observable<String> {
+        self.messageField.rx.text
+            .orEmpty
+            .asObservable()
+    }
+    
+    var tapProfileEvent: ControlEvent<Void> {
+        return ControlEvent(
+            events: self.profileImageView.rx
+                .tapGesture()
+                .when(.ended)
+                .map { _ in () })
+    }
+    
+    var profileImage: AnyObserver<UIImage?> {
+        return self.profileImageView.rx.image
+            .asObserver()
+    }
+}
+
+private extension ProfileSettingView {
+    func addSubViews() {
+        [profileImageView, nicknameField, messageField].forEach {
+            self.addSubview($0)
+        }
+    }
+    
+    func configureConstraints() {
+        self.configureProfileImageView()
+        self.configureNickNameField()
+        self.configureMessageField()
+    }
+    
+    func configureProfileImageView() {
+        profileImageView.snp.makeConstraints { (make) in
+            make.horizontalEdges.top.equalTo(self.safeAreaLayoutGuide)
+            make.height.equalTo(profileImageView.snp.width)
+        }
+    }
+    
+    func configureNickNameField() {
+        nicknameField.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
+            make.top.equalTo(profileImageView.snp.bottom).offset(30)
+            make.height.equalTo(nicknameField.snp.width).multipliedBy(0.15)
+        }
+    }
+    
+    func configureMessageField() {
+        messageField.snp.makeConstraints { (make) in
+            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
+            make.top.equalTo(nicknameField.snp.bottom).offset(30)
+            make.height.equalTo(messageField.snp.width).multipliedBy(0.15)
+        }
+    }
+}

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
@@ -11,7 +11,7 @@ import RxSwift
 import SnapKit
 import UIKit
 
-typealias KeyboardShowValues = (frame: CGRect, curve: Int, duration: Double)
+typealias KeyboardShowValues = (frame: CGRect, curve: UIView.AnimationCurve, duration: Double)
 
 final class ProfileSettingView: UIView {
     // MARK: - UI properties
@@ -71,6 +71,12 @@ final class ProfileSettingView: UIView {
 }
 
 extension ProfileSettingView {    
+    var height: CGFloat {
+        self.subviews.reduce(30 + 10 + 10 + 30 + 10 + 10) { partialResult, subView in
+            partialResult + subView.frame.height
+        }
+    }
+    
     var nickNameText: Observable<String> {
         self.nicknameField.rx.text
             .orEmpty

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingView.swift
@@ -11,8 +11,6 @@ import RxSwift
 import SnapKit
 import UIKit
 
-typealias KeyboardShowValues = (frame: CGRect, curve: UIView.AnimationCurve, duration: Double)
-
 final class ProfileSettingView: UIView {
     // MARK: - UI properties
     private let profileImageView: UIImageView = UIImageView().then {
@@ -138,95 +136,6 @@ extension ProfileSettingView {
             .filter { _ in
                 self.messageField.isFirstResponder
             }
-    }
-    
-    func moveUpKeyboardAboveNickName(userInfo: [AnyHashable: Any]) {
-        print(#function)
-        
-        guard let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
-              let keyboardAnimationCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
-              let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
-              let keyboardCurve = UIView.AnimationCurve(rawValue: keyboardAnimationCurve)
-        else {
-            return
-        }
-        
-        let keyboardSize: CGRect = keyboardFrame
-        let keyboardHeight: CGFloat = keyboardSize.height
-        
-        let newConstant = keyboardHeight - (self.frame.height - self.profileImageView.frame.height - self.nickNameLabel.frame.height - self.nicknameField.frame.height - self.nickNameValidityMessageLabel.frame.height - 50)
-        
-        self.profileImageView.snp.remakeConstraints { make in
-            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
-            make.height.equalTo(profileImageView.snp.width)
-            make.top.equalTo(self.safeAreaLayoutGuide).offset(-newConstant)
-        }
-        
-        self.messageLabel.snp.makeConstraints { (make) in
-            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
-            make.top.equalTo(nickNameValidityMessageLabel.snp.bottom).offset(30 + keyboardHeight)
-        }
-        
-        let animator = UIViewPropertyAnimator(duration: keyboardDuration, curve: keyboardCurve) { [weak self] in
-            self?.layoutIfNeeded()
-        }
-        
-        animator.startAnimation()
-    }
-    
-    func moveUpKeyboardAboveMessage(userInfo: [AnyHashable: Any]) {
-        print(#function)
-        
-        guard let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
-              let keyboardAnimationCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
-              let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
-              let keyboardCurve = UIView.AnimationCurve(rawValue: keyboardAnimationCurve)
-        else {
-            return
-        }
-        
-        let keyboardSize: CGRect = keyboardFrame
-        let keyboardHeight: CGFloat = keyboardSize.height
-        let newConstant = keyboardHeight
-        
-        self.profileImageView.snp.remakeConstraints { make in
-            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
-            make.height.equalTo(profileImageView.snp.width)
-            make.top.equalTo(self.safeAreaLayoutGuide).offset(-newConstant)
-        }
-        
-        let animator = UIViewPropertyAnimator(duration: keyboardDuration, curve: keyboardCurve) { [weak self] in
-            self?.layoutIfNeeded()
-        }
-        
-        animator.startAnimation()
-    }
-
-    func moveDownKeyboard(userInfo: [AnyHashable: Any]) {
-        print(#function)
-        self.endEditing(true)
-        guard let keyboardAnimationCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
-              let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
-              let keyboardCurve = UIView.AnimationCurve(rawValue: keyboardAnimationCurve)
-        else {
-            return
-        }
-        
-        self.profileImageView.snp.remakeConstraints { make in
-            make.horizontalEdges.top.equalTo(self.safeAreaLayoutGuide)
-            make.height.equalTo(profileImageView.snp.width)
-        }
-
-        self.messageLabel.snp.makeConstraints { (make) in
-            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
-            make.top.equalTo(nickNameValidityMessageLabel.snp.bottom).offset(30)
-        }
-        
-        let animator = UIViewPropertyAnimator(duration: keyboardDuration, curve: keyboardCurve) { [weak self] in
-            self?.layoutIfNeeded()
-        }
-        
-        animator.startAnimation()
     }
     
     var nickNameValidityMessage: AnyObserver<String?> {

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
@@ -43,6 +43,7 @@ final class ProfileSettingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureNavigationBar()
+        self.view.backgroundColor = .white
         self.scrollView.addSubview(self.rootView)
         self.bindToViewModel()
     }

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
@@ -83,10 +83,6 @@ private extension ProfileSettingViewController {
     func configureNavigationBar() {
         self.navigationItem.title = "프로필 설정"
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "등록", style: .plain, target: self, action: nil)
-        self.navigationItem.largeTitleDisplayMode = .automatic
-        if let navigationBar = self.navigationController?.navigationBar {
-            self.rootView.bringSubviewToFront(navigationBar)
-        }
         self.navigationController?.isNavigationBarHidden = false
     }
     

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
@@ -101,11 +101,11 @@ private extension ProfileSettingViewController {
             .disposed(by: self.disposeBag)
         self.rootView.keyboardWillShowOnNickNameField
             .compactMap { self.keyboardNotificationHandler($0) }
-            .drive(onNext: { self.moveKeyboardUp(keyboardShowValue: $0) })
+            .drive(onNext: { self.moveKeyboardUp(keyboardHeight: $0) })
             .disposed(by: self.disposeBag)
         self.rootView.keyboardWillDismissFromNickNameField
-            .compactMap { self.keyboardNotificationHandler($0) }
-            .drive(onNext: { self.moveKeyboardDown(keyboardShowValue: $0) })
+            .filter { self.keyboardNotificationHandler($0) != nil }
+            .drive(onNext: { _ in self.moveKeyboardDown() })
             .disposed(by: self.disposeBag)
     }
     
@@ -131,11 +131,11 @@ private extension ProfileSettingViewController {
             .disposed(by: self.disposeBag)
         self.rootView.keyboardWillShowOnMessageField
             .compactMap { self.keyboardNotificationHandler($0) }
-            .drive(onNext: { self.moveKeyboardUp(keyboardShowValue: $0) })
+            .drive(onNext: { self.moveKeyboardUp(keyboardHeight: $0) })
             .disposed(by: self.disposeBag)
         self.rootView.keyboardWillDismissFromMessageField
-            .compactMap { self.keyboardNotificationHandler($0) }
-            .drive(onNext: { self.moveKeyboardDown(keyboardShowValue: $0) })
+            .filter { self.keyboardNotificationHandler($0) != nil }
+            .drive(onNext: { _ in self.moveKeyboardDown() })
             .disposed(by: self.disposeBag)
     }
     
@@ -168,58 +168,22 @@ private extension ProfileSettingViewController {
     }
 }
 
-extension UIScrollView {
-    func updateContentSize() {
-        let unionCalculatedTotalRect = recursiveUnionInDepthFor(view: self)
-        
-        // 계산된 크기로 컨텐츠 사이즈 설정
-        self.contentSize = CGSize(width: self.frame.width, height: unionCalculatedTotalRect.height + 50)
-    }
-    
-    private func recursiveUnionInDepthFor(view: UIView) -> CGRect {
-        var totalRect: CGRect = .zero
-        
-        // 모든 자식 View의 컨트롤의 크기를 재귀적으로 호출하며 최종 영역의 크기를 설정
-        for subView in view.subviews {
-            totalRect = totalRect.union(recursiveUnionInDepthFor(view: subView))
-        }
-        
-        // 최종 계산 영역의 크기를 반환
-        return totalRect.union(view.frame)
-    }
-}
-
 extension UIViewController {
-    func keyboardNotificationHandler(_ notification: Notification) -> KeyboardShowValues? {
-        print(#function)
-        
+    func keyboardNotificationHandler(_ notification: Notification) -> CGFloat? {
         guard let userInfo = notification.userInfo,
-              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey]  as? CGRect,
-              let keyboardAnimationCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
-              let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
-              let keyboardCurve = UIView.AnimationCurve(rawValue: keyboardAnimationCurve)
-        else {
+              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey]  as? CGRect else {
             return nil
         }
-        return KeyboardShowValues(keyboardFrame, keyboardCurve, keyboardDuration)
+        return keyboardFrame.height
     }
 }
 
 extension ProfileSettingViewController {
-    func moveKeyboardUp(keyboardShowValue: KeyboardShowValues) {
-//        let animator = UIViewPropertyAnimator(duration: keyboardShowValue.duration, curve: keyboardShowValue.curve) { [weak self] in
-//            self?.view.layoutIfNeeded()
-//        }
-//
-//        animator.startAnimation()
-        self.scrollToUp(keyboardHeight: keyboardShowValue.frame.height)
+    func moveKeyboardUp(keyboardHeight: CGFloat) {
+        self.scrollToUp(keyboardHeight: keyboardHeight)
     }
     
-    func moveKeyboardDown(keyboardShowValue: KeyboardShowValues) {
-//        let animator = UIViewPropertyAnimator(duration: keyboardShowValue.duration, curve: keyboardShowValue.curve) { [weak self] in
-//            self?.view.layoutIfNeeded()
-//        }
-//        animator.startAnimation()
+    func moveKeyboardDown() {
         self.scrollToDown()
     }
     

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 import Then
 import UIKit
 
-final class ProfileSettingViewController: UIViewController, UIScrollViewDelegate {
+final class ProfileSettingViewController: UIViewController {
     // MARK: - UI properties
     private let rootView: ProfileSettingView = ProfileSettingView()
     private let scrollView: UIScrollView = UIScrollView().then {
@@ -57,10 +57,6 @@ final class ProfileSettingViewController: UIViewController, UIScrollViewDelegate
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollView.contentOffset.x = 0
     }
 }
 
@@ -178,7 +174,7 @@ extension UIViewController {
     }
 }
 
-extension ProfileSettingViewController {
+private extension ProfileSettingViewController {
     func moveKeyboardUp(keyboardHeight: CGFloat) {
         self.scrollToUp(keyboardHeight: keyboardHeight)
     }

--- a/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
+++ b/NearTalk/NearTalk/Presentation/ProfileSetting/View/ProfileSettingViewController.swift
@@ -12,22 +12,51 @@ import SnapKit
 import Then
 import UIKit
 
-final class ProfileSettingViewController: UIViewController {
+final class ProfileSettingViewController: UIViewController, UIScrollViewDelegate {
     // MARK: - UI properties
-    private lazy var rootView: ProfileSettingView = ProfileSettingView()
+    private let rootView: ProfileSettingView = ProfileSettingView()
+    private let scrollView: UIScrollView = UIScrollView().then {
+        $0.keyboardDismissMode = .onDrag
+        $0.alwaysBounceHorizontal = false
+    }
     
     // MARK: - Properties
     private let disposeBag: DisposeBag = DisposeBag()
     private let viewModel: any ProfileSettingViewModel
 
     // MARK: - Lifecycles
+    override func viewWillLayoutSubviews() {
+//        self.rootView.frame = self.view.frame
+        super.viewWillLayoutSubviews()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+//        super.viewDidAppear(animated)
+//        let subViewsheight: CGFloat = self.rootView.subviews.reduce(0, { partialResult, view in
+//            partialResult + view.frame.height
+//        })
+//        let height: CGFloat = self.view.frame.height + subViewsheight
+//        self.scrollView.contentSize = .init(width: self.view.frame.width, height: height)
+        self.scrollView.updateContentSize()
+    }
+    
     override func loadView() {
-        self.view = self.rootView
+        self.view = self.scrollView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureNavigationBar()
+        self.scrollView.addSubview(self.rootView)
+        self.rootView.snp.makeConstraints { make in
+            make.edges.equalTo(self.scrollView.contentLayoutGuide)
+            make.width.equalToSuperview()
+            make.height.equalToSuperview().priority(.low)
+        }
+//        self.scrollView.snp.makeConstraints { make in
+//            make.edges.width.equalTo(self.view.safeAreaLayoutGuide)
+//        }
+        
         self.bindToViewModel()
     }
     
@@ -42,18 +71,23 @@ final class ProfileSettingViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollView.contentOffset.x = 0
+    }
 }
 
 // MARK: - Helpers
 private extension ProfileSettingViewController {
     
     func configureNavigationBar() {
-//        self.navigationController?.navigationBar.backgroundColor = .systemGray5
-//        self.navigationController?.navigationBar.isTranslucent = false
         self.navigationItem.title = "프로필 설정"
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "등록", style: .plain, target: self, action: nil)
         self.navigationItem.largeTitleDisplayMode = .automatic
-//        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16, weight: .bold)]
+        if let navigationBar = self.navigationController?.navigationBar {
+            self.rootView.bringSubviewToFront(navigationBar)
+        }
+        self.navigationController?.isNavigationBarHidden = false
     }
     
     func bindToViewModel() {
@@ -67,8 +101,29 @@ private extension ProfileSettingViewController {
         self.rootView.nickNameText
             .bind(onNext: { [weak self] text in
                 self?.viewModel.editNickName(text)
-                
             })
+            .disposed(by: self.disposeBag)
+        self.viewModel.nickNameValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? "사용 가능한 닉네임 입니다" : "5-16 자 사이의 영어 소문자, 숫자, -_ 기호만 사용하십시오"
+            }
+            .drive(self.rootView.nickNameValidityMessage)
+            .disposed(by: self.disposeBag)
+        self.viewModel.nickNameValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? UIColor.green : UIColor.red
+            }
+            .drive(self.rootView.nickNameValidityColor)
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillShowOnNickNameField
+            .compactMap { $0.userInfo }
+            .drive(onNext: { self.rootView.moveUpKeyboardAboveNickName(userInfo: $0) })
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillDismissFromNickNameField
+            .compactMap { $0.userInfo }
+            .drive(onNext: { self.rootView.moveDownKeyboard(userInfo: $0) })
             .disposed(by: self.disposeBag)
     }
     
@@ -77,6 +132,28 @@ private extension ProfileSettingViewController {
             .bind(onNext: { [weak self] text in
                 self?.viewModel.editStatusMessage(text)
             })
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillShowOnMessageField
+            .compactMap { $0.userInfo }
+            .drive(onNext: { self.rootView.moveUpKeyboardAboveMessage(userInfo: $0) })
+            .disposed(by: self.disposeBag)
+        self.rootView.keyboardWillDismissFromMessageField
+            .compactMap { $0.userInfo }
+            .drive(onNext: { self.rootView.moveDownKeyboard(userInfo: $0) })
+            .disposed(by: self.disposeBag)
+        self.viewModel.messageValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? "사용 가능한 메세지 입니다" : "50자 이하로 작성하십시오"
+            }
+            .drive(self.rootView.messageValidityMessage)
+            .disposed(by: self.disposeBag)
+        self.viewModel.messageValidity
+            .asDriver()
+            .map { isValid in
+                isValid ? UIColor.green : UIColor.red
+            }
+            .drive(self.rootView.messageValidityColor)
             .disposed(by: self.disposeBag)
     }
     
@@ -106,5 +183,26 @@ private extension ProfileSettingViewController {
                 })
                 .disposed(by: self.disposeBag)
         }
+    }
+}
+
+extension UIScrollView {
+    func updateContentSize() {
+        let unionCalculatedTotalRect = recursiveUnionInDepthFor(view: self)
+        
+        // 계산된 크기로 컨텐츠 사이즈 설정
+        self.contentSize = CGSize(width: self.frame.width, height: unionCalculatedTotalRect.height+50)
+    }
+    
+    private func recursiveUnionInDepthFor(view: UIView) -> CGRect {
+        var totalRect: CGRect = .zero
+        
+        // 모든 자식 View의 컨트롤의 크기를 재귀적으로 호출하며 최종 영역의 크기를 설정
+        for subView in view.subviews {
+            totalRect = totalRect.union(recursiveUnionInDepthFor(view: subView))
+        }
+        
+        // 최종 계산 영역의 크기를 반환
+        return totalRect.union(view.frame)
     }
 }

--- a/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
+++ b/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
@@ -73,8 +73,8 @@ final class RootTabBarCoordinator: Coordinator {
         return self.embed(
             rootNav: navigationController,
             title: "친구",
-            inactivatedImage: UIImage(systemName: "figure.2.arms.open")?.withTintColor(.darkGray),
-            activatedImage: UIImage(systemName: "figure.2.arms.open")?.withTintColor(.blue)
+            inactivatedImage: UIImage(systemName: "person.3")?.withTintColor(.darkGray),
+            activatedImage: UIImage(systemName: "person.3.fill")?.withTintColor(.blue)
         )
     }
 
@@ -91,8 +91,8 @@ final class RootTabBarCoordinator: Coordinator {
         return self.embed(
             rootNav: navigationController,
             title: "마이페이지",
-            inactivatedImage: UIImage(systemName: "figure.wave")?.withTintColor(.darkGray),
-            activatedImage: UIImage(systemName: "figure.wave")?.withTintColor(.blue)
+            inactivatedImage: UIImage(systemName: "person")?.withTintColor(.darkGray),
+            activatedImage: UIImage(systemName: "person.fill")?.withTintColor(.blue)
         )
     }
     


### PR DESCRIPTION
## 개요

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [x] New Feature
- [x] 버그 수정
- [x] 그 외

## 설명(Description)
- [x] 로그인 화면 로고 위치, 버튼 크기 변경
- [x] 마이프로필 네비게이션 바 분리 버그 픽스
- [x] 프로필 수정, 온보딩 화면 라벨 추가
- [x] 온보딩, 프로필 수정 화면 UIView 추가
- [x] 앱설정, 마이 프로필 화면 TableViewCell의 Separator 삐져 나오는 버그 픽스
- [x] 앱설정, 마이 프로필 화면 TableView의 하단 모서리가 둥글지 않는 버그 픽스
- [x] 마이 프로필 화면 닉네임, 상태메세지 라벨 추가
- [x] 프로필 수정, 온보딩 화면 키보드 텍스트 필드 밑에 올라오는 작업 추가
- [x] 실기기에서 프로필 수정, 온보딩 화면 상태 메세지 필드 클릭시 키보드 올라오지 않는 버그 픽스
- [x] UIViewController Extension으로 키보드 푸쉬 이벤트 Notification 받을 때, 키보드 높이 반환하는 함수 추가 

## Screenshot(제작 화면)
### 로그인 화면
<img width="862" alt="스크린샷 2022-12-01 11 21 22" src="https://user-images.githubusercontent.com/46563413/204950521-18372b1f-dcb2-4279-ba9b-b6ba1029bad4.png">

### 온보딩 화면
![Simulator Screen Recording - iPhone 14 Pro - 2022-12-01 at 20 39 25](https://user-images.githubusercontent.com/46563413/205045077-1c390f55-945e-4621-9cac-9bb9e20d5f25.gif)

### 마이프로필 화면
- UI
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-01 at 14 51 05](https://user-images.githubusercontent.com/46563413/204976279-03ab5cc0-fbad-4600-855c-f813e8894e4e.png)

- 키보드 동작
![Simulator Screen Recording - iPhone 14 Pro - 2022-12-01 at 19 15 37](https://user-images.githubusercontent.com/46563413/205027360-05dcdb4c-7e31-4abb-baca-39cad32dee79.gif)

### 프로필 수정 화면
<img width="862" alt="스크린샷 2022-12-01 11 20 52" src="https://user-images.githubusercontent.com/46563413/204950543-9f37d215-ea50-45a4-b74b-a8adb91440ed.png">

### 앱 설정 화면
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-01 at 14 28 53](https://user-images.githubusercontent.com/46563413/204973134-8926108d-37e7-46f5-b2d2-96b189117eb4.png)

## 주의사항 및 기타comments
### 프로필화면 
- 키보드 올라오고 내려오는 이벤트 Handling 함수 통합 필요