### PR TITLE
[회원 탈퇴, 로그인] 회원 탈퇴 및 로그인 후 메인화면으로 넘어가는 버그 픽스 

### DIFF
--- a/NearTalk/NearTalk/Application/DIContainer/AppSettingDIContainer.swift
+++ b/NearTalk/NearTalk/Application/DIContainer/AppSettingDIContainer.swift
@@ -35,7 +35,7 @@ final class DefaultAppSettingDIContainer: AppSettingCoordinatorDependency {
     private func makeDropoutUseCase() -> any DropoutUseCase {
         return DefaultDropOutUseCase(
             profileRepository: self.dependency.profileRepository,
-            userDefaultsRepository: self.dependency.userDefaultsRepository)
+            userDefaultsRepository: self.dependency.userDefaultsRepository, authRepository: self.dependency.authRepository)
     }
     
     private let dependency: Dependency

--- a/NearTalk/NearTalk/Application/DIContainer/LoginDIContainer.swift
+++ b/NearTalk/NearTalk/Application/DIContainer/LoginDIContainer.swift
@@ -15,6 +15,7 @@ final class LoginDIContainer {
         self.container = Container(parent: container)
         
         self.registerLoginUseCase()
+        self.registerVerifyUseCase()
         self.registerViewModel(loginAction: actions)
     }
     
@@ -24,11 +25,17 @@ final class LoginDIContainer {
         }
     }
     
+    private func registerVerifyUseCase() {
+        self.container.register(VerifyUserUseCase.self) { _ in
+            DefaultVerifyUserUseCase(authRepository: self.container.resolve(AuthRepository.self)!, profileRepository: self.container.resolve(ProfileRepository.self)!, userDefaultsRepository: self.container.resolve(UserDefaultsRepository.self)!)
+        }
+    }
+    
     private func registerViewModel(loginAction: LoginAction) {
         self.container.register(LoginViewModel.self) { _ in
             DefaultLoginViewModel(
                 action: loginAction,
-                loginUseCase: self.container.resolve(LoginUseCase.self)!
+                loginUseCase: self.container.resolve(LoginUseCase.self)!, verifyUseCase: self.container.resolve(VerifyUserUseCase.self)!
             )
         }
     }

--- a/NearTalk/NearTalk/Data/Repositories/DefaultAuthRepository.swift
+++ b/NearTalk/NearTalk/Data/Repositories/DefaultAuthRepository.swift
@@ -18,6 +18,10 @@ final class DefaultAuthRepository: AuthRepository {
         return self.authService.logout()
     }
     
+    func reauthenticate(token: String) -> Completable {
+        return self.authService.reauthenticateUser(idTokenString: token, nonce: NonceGenerator.randomNonceString())
+    }
+    
     func dropout() -> Completable {
         return self.authService.deleteCurrentUser()
     }

--- a/NearTalk/NearTalk/Data/Repositories/DummyAuthRepository.swift
+++ b/NearTalk/NearTalk/Data/Repositories/DummyAuthRepository.swift
@@ -57,4 +57,11 @@ final class DummyAuthRepository: AuthRepository {
             return Disposables.create()
         }
     }
+    
+    func reauthenticate(token: String) -> Completable {
+        Completable.create { completable in
+            completable(.completed)
+            return Disposables.create()
+        }
+    }
 }

--- a/NearTalk/NearTalk/Domain/Interfaces/Repositories/AuthRepository.swift
+++ b/NearTalk/NearTalk/Domain/Interfaces/Repositories/AuthRepository.swift
@@ -12,5 +12,5 @@ protocol AuthRepository {
     func dropout() -> Completable
     func login(token: String) -> Completable
     func verify() -> Completable
-//    func fetchCurrentUserUID() -> Single<String>
+    func reauthenticate(token: String) -> Completable
 }

--- a/NearTalk/NearTalk/Domain/UseCases/DropOutUseCase.swift
+++ b/NearTalk/NearTalk/Domain/UseCases/DropOutUseCase.swift
@@ -8,22 +8,31 @@
 import RxSwift
 
 protocol DropoutUseCase {
-    func execute() -> Completable
+    func reauthenticate(token: String) -> Completable
+    func dropout() -> Completable
 }
 
 final class DefaultDropOutUseCase: DropoutUseCase {
     private let profileRepository: any ProfileRepository
     private let userDefaultsRepository: any UserDefaultsRepository
+    private let authRepository: any AuthRepository
     
     init(profileRepository: any ProfileRepository,
-         userDefaultsRepository: any UserDefaultsRepository) {
+         userDefaultsRepository: any UserDefaultsRepository,
+         authRepository: any AuthRepository) {
         self.profileRepository = profileRepository
         self.userDefaultsRepository = userDefaultsRepository
+        self.authRepository = authRepository
     }
     
-    func execute() -> Completable {
+    func reauthenticate(token: String) -> Completable {
+        self.authRepository.reauthenticate(token: token)
+    }
+    
+    func dropout() -> Completable {
         userDefaultsRepository.removeUserProfile()
         return self.deleteProfile()
+            .andThen(self.authRepository.dropout())
     }
     
     private func deleteProfile() -> Completable {

--- a/NearTalk/NearTalk/Infrastructure/Network/AuthService.swift
+++ b/NearTalk/NearTalk/Infrastructure/Network/AuthService.swift
@@ -14,5 +14,6 @@ protocol AuthService {
     func loginWithApple(token idTokenString: String, nonce: String) -> Completable
     func logout() -> Completable
     func deleteCurrentUser() -> Completable
+    func reauthenticateUser(idTokenString: String, nonce: String?) -> Completable
 //    func fetchCurrentUID() -> Single<String>
 }

--- a/NearTalk/NearTalk/Presentation/AppSetting/Coordinator/AppSettingCoordinator.swift
+++ b/NearTalk/NearTalk/Presentation/AppSetting/Coordinator/AppSettingCoordinator.swift
@@ -30,7 +30,7 @@ final class AppSettingCoordinator: Coordinator {
         let viewController: AppSettingViewController = self.dependency.makeAppSettingViewController(
             action: Action(presentLogoutResult: self.presentLogoutResult(success:),
                            presentDropoutResult: self.presentDropoutResult(success:),
-                           presentNotificationPrompt: self.presentNotificationPrompt))
+                           presentNotificationPrompt: self.presentNotificationPrompt, presentReauthenticateView: self.presentAppleAuthenticateViewController))
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
@@ -38,6 +38,7 @@ final class AppSettingCoordinator: Coordinator {
         let presentLogoutResult: ((Bool) -> Void)?
         let presentDropoutResult: ((Bool) -> Void)?
         let presentNotificationPrompt: (() -> Single<Bool>)?
+        let presentReauthenticateView: (() -> Void)?
     }
     
     func presentLogoutResult(success: Bool) {
@@ -83,6 +84,10 @@ final class AppSettingCoordinator: Coordinator {
             self?.navigationController?.topViewController?.present(alert, animated: true)
             return Disposables.create()
         }
+    }
+    
+    func presentAppleAuthenticateViewController() {
+        (self.navigationController?.topViewController as? AppSettingViewController)?.presentReauthenticationViewController()
     }
     
     @MainActor

--- a/NearTalk/NearTalk/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/NearTalk/NearTalk/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -25,19 +25,33 @@ final class DefaultLoginViewModel: LoginViewModel {
     func requestFireBaseLogin(token: String) {
         self.loginUseCase.login(token: token)
             .subscribe { [weak self] in
-                self?.action.presentMainView?()
+                self?.requestProfileExistence()
             } onError: { [weak self] _ in
                 self?.action.presentLoginFailure?()
             }
             .disposed(by: self.disposeBag)
     }
     
+    func requestProfileExistence() {
+        self.verifyUseCase.verifyProfile()
+            .subscribe { [weak self] in
+                self?.action.presentMainView?()
+            } onError: { [weak self] _ in
+                self?.action.presentOnboardingView?()
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
     private let action: LoginAction
     private let loginUseCase: any LoginUseCase
+    private let verifyUseCase: any VerifyUserUseCase
     private let disposeBag: DisposeBag = DisposeBag()
     
-    init(action: LoginAction, loginUseCase: any LoginUseCase) {
+    init(action: LoginAction,
+         loginUseCase: any LoginUseCase,
+         verifyUseCase: any VerifyUserUseCase) {
         self.action = action
         self.loginUseCase = loginUseCase
+        self.verifyUseCase = verifyUseCase
     }
 }


### PR DESCRIPTION
## 개요
resolved #37
resolved #6 

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [x] New Feature
- [x] 버그 수정
- [ ] 그 외

## 설명(Description)
- [x] 앱 설정 화면에서 탈퇴 시 애플 로그인으로 재인증 요구 기능 추가
- [x] AuthService, AuthRepository, DropUseCase에 재인증 메서드 추가
- [x] Login시 프로필 유무 검사 확인해서 메인화면, 온보딩 화면 중 넘어갈 화면 선택 로직 추가
- [x] 앱 탈퇴 후, 다시 킬 때, 바로 온보딩 화면으로 넘어가는 버그 픽스 
- [x] 앱 가입 시, Apple 로그인 후, 온보딩이 아닌 메인 화면으로 바로 넘어가는 버그 픽스

## Screenshot(제작 화면)
https://user-images.githubusercontent.com/46563413/205341098-d5aeec63-6953-418f-b99d-ec53f729f759.mp4

## 주의사항 및 기타comments