### PR TITLE
[로그인>로그인 버튼] 애플 로그인 완료 후 앱 전환 직전까지 로그인 버튼 비활성화 처리

### DIFF
--- a/NearTalk/NearTalk/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/NearTalk/NearTalk/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -5,12 +5,21 @@
 //  Created by Preston Kim on 2022/11/23.
 //
 
+import AuthenticationServices.ASAuthorization
 import Foundation
-import RxRelay
+import RxCocoa
 import RxSwift
 
 protocol LoginInput {
-    func requestFireBaseLogin(token: String)
+    func receiveAppleLoginResult(authorization: ASAuthorization)
+    func receiveAppleLoginFailure()
+    func requestAppleLogin() -> ASAuthorizationAppleIDRequest
+    func viewWillDisappear()
+    func viewWillAppear()
+}
+
+protocol LoginOutput {
+    var loginEnable: Driver<Bool> { get }
 }
 
 struct LoginAction {
@@ -19,20 +28,43 @@ struct LoginAction {
     var presentLoginFailure: (() -> Void)?
 }
 
-protocol LoginViewModel: LoginInput {}
+protocol LoginViewModel: LoginInput, LoginOutput {}
 
-final class DefaultLoginViewModel: LoginViewModel {
-    func requestFireBaseLogin(token: String) {
+final class DefaultLoginViewModel {
+    private let action: LoginAction
+    private let loginUseCase: any LoginUseCase
+    private let verifyUseCase: any VerifyUserUseCase
+    private let disposeBag: DisposeBag = DisposeBag()
+    private let loginEnableRelay: BehaviorRelay<Bool> = BehaviorRelay(value: true)
+    
+    init(action: LoginAction,
+         loginUseCase: any LoginUseCase,
+         verifyUseCase: any VerifyUserUseCase) {
+        self.action = action
+        self.loginUseCase = loginUseCase
+        self.verifyUseCase = verifyUseCase
+    }
+}
+
+private extension DefaultLoginViewModel {
+    func requestFirebaseLogin(token: String) {
+        #if DEBUG
+        print(#function)
+        #endif
         self.loginUseCase.login(token: token)
             .subscribe { [weak self] in
                 self?.requestProfileExistence()
             } onError: { [weak self] _ in
                 self?.action.presentLoginFailure?()
+                self?.loginEnableRelay.accept(true)
             }
             .disposed(by: self.disposeBag)
     }
     
     func requestProfileExistence() {
+        #if DEBUG
+        print(#function)
+        #endif
         self.verifyUseCase.verifyProfile()
             .subscribe { [weak self] in
                 self?.action.presentMainView?()
@@ -41,17 +73,59 @@ final class DefaultLoginViewModel: LoginViewModel {
             }
             .disposed(by: self.disposeBag)
     }
+}
+
+extension DefaultLoginViewModel: LoginViewModel {
+    var loginEnable: Driver<Bool> {
+        self.loginEnableRelay
+            .asDriver()
+    }
     
-    private let action: LoginAction
-    private let loginUseCase: any LoginUseCase
-    private let verifyUseCase: any VerifyUserUseCase
-    private let disposeBag: DisposeBag = DisposeBag()
+    func receiveAppleLoginResult(authorization: ASAuthorization) {
+        #if DEBUG
+        print(#function)
+        #endif
+        switch authorization.credential {
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+            guard let userIdentifier = appleIDCredential.identityToken, let idTokenString = String(data: userIdentifier, encoding: .utf8) else {
+                #if DEBUG
+                print("Failed to fetch Apple ID Token")
+                #endif
+                self.loginEnableRelay.accept(true)
+                break
+            }
+            self.requestFirebaseLogin(token: idTokenString)
+        default:
+            self.loginEnableRelay.accept(true)
+        }
+    }
     
-    init(action: LoginAction,
-         loginUseCase: any LoginUseCase,
-         verifyUseCase: any VerifyUserUseCase) {
-        self.action = action
-        self.loginUseCase = loginUseCase
-        self.verifyUseCase = verifyUseCase
+    func receiveAppleLoginFailure() {
+        self.loginEnableRelay.accept(true)
+    }
+
+    func requestAppleLogin() -> ASAuthorizationAppleIDRequest {
+        #if DEBUG
+        print(#function)
+        #endif
+        self.loginEnableRelay.accept(false)
+        let appleIDProvider: ASAuthorizationAppleIDProvider = ASAuthorizationAppleIDProvider()
+        let request: ASAuthorizationAppleIDRequest = appleIDProvider.createRequest()
+        request.requestedScopes = [.email, .fullName]
+        return request
+    }
+    
+    func viewWillAppear() {
+        #if DEBUG
+        print(#function)
+        #endif
+        self.loginEnableRelay.accept(true)
+    }
+    
+    func viewWillDisappear() {
+        #if DEBUG
+        print(#function)
+        #endif
+        self.loginEnableRelay.accept(false)
     }
 }


### PR DESCRIPTION
## 개요
resolved #142 

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [ ] New Feature
- [x] 버그 수정
- [x] 그 외

## 설명(Description)
- [x] 로그인 관련 비지니스 로직을 ViewModel로 옮겨 리팩토링
- [x] 애플 로그인 성공 후, 화면 전환 전까지 Apple 로그인 버튼 비활성화 처리

## Screenshot(제작 화면)

## 주의사항 및 기타comments