### PR TITLE
[로그인, 온보딩>화면] 로그인 로고 교체, UI 관련 버그 픽스

### DIFF
--- a/NearTalk/NearTalk/Application/Coordinator/AppCoordinator.swift
+++ b/NearTalk/NearTalk/Application/Coordinator/AppCoordinator.swift
@@ -73,6 +73,7 @@ extension AppCoordinator: LoginCoordinatorDependency {
         guard let appDIContainer else {
             return
         }
+        self.navigationController?.navigationBar.isHidden = false
         let onboardingDIContainer: DefaultOnboardingDIContainer = appDIContainer.resolveOnboardingDIContainer()
         let onboardingCoordinator: OnboardingCoordinator = OnboardingCoordinator(
             container: onboardingDIContainer,
@@ -82,7 +83,6 @@ extension AppCoordinator: LoginCoordinatorDependency {
     }
     
     func backToLoginView() {
-        self.navigationController?.dismiss(animated: false)
         self.navigationController?.popToRootViewController(animated: false)
     }
 }

--- a/NearTalk/NearTalk/Infrastructure/Utils/UserProfileInputViewController.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/UserProfileInputViewController.swift
@@ -63,19 +63,10 @@ class UserProfileInputViewController: PhotoImagePickerViewController {
         newNavBarAppearance.configureWithOpaqueBackground()
         newNavBarAppearance.backgroundColor = .secondaryBackground
         
-        self.navigationController?.navigationBar.tintColor = .label
         self.navigationItem.standardAppearance = newNavBarAppearance
         self.navigationItem.compactAppearance = newNavBarAppearance
         self.navigationItem.scrollEdgeAppearance = newNavBarAppearance
         self.navigationItem.compactScrollEdgeAppearance = newNavBarAppearance
-        self.navigationController?.isNavigationBarHidden = false
-        self.navigationController?.navigationBar.backgroundColor = .secondaryBackground
-        self.navigationController?.navigationBar.standardAppearance = newNavBarAppearance
-        self.navigationController?.navigationBar.compactAppearance = newNavBarAppearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = newNavBarAppearance
-        self.navigationController?.navigationBar.compactScrollEdgeAppearance = newNavBarAppearance
-        self.navigationController?.navigationBar.topItem?.backButtonTitle = nil
-        self.navigationController?.navigationBar.isTranslucent = false
     }
     
     func configureScrollViewConstraint() {

--- a/NearTalk/NearTalk/Presentation/Login/View/LoginViewController.swift
+++ b/NearTalk/NearTalk/Presentation/Login/View/LoginViewController.swift
@@ -14,7 +14,7 @@ import Then
 import UIKit
 
 final class LoginViewController: UIViewController {
-    private let logoView = UIImageView(image: UIImage(named: "ChatLogo"))
+    private let logoView: UIImageView = UIImageView(image: UIImage(named: "ChatLogo"))
     private let loginButton: ASAuthorizationAppleIDButton = ASAuthorizationAppleIDButton(type: .signIn, style: .whiteOutline).then {
         $0.cornerRadius = 5
     }
@@ -47,9 +47,10 @@ final class LoginViewController: UIViewController {
         super.viewWillDisappear(animated)
     }
 }
+
 private extension LoginViewController {
     func configureUI() {
-        self.view.backgroundColor = .systemBackground
+        self.view.backgroundColor = .primaryBackground
         view.addSubview(logoView)
         view.addSubview(loginButton)
     }

--- a/NearTalk/NearTalk/Presentation/Login/View/LoginViewController.swift
+++ b/NearTalk/NearTalk/Presentation/Login/View/LoginViewController.swift
@@ -14,7 +14,7 @@ import Then
 import UIKit
 
 final class LoginViewController: UIViewController {
-    private let logoView = UIImageView(image: UIImage(systemName: "map.circle.fill"))
+    private let logoView = UIImageView(image: UIImage(named: "ChatLogo"))
     private let loginButton: ASAuthorizationAppleIDButton = ASAuthorizationAppleIDButton(type: .signIn, style: .whiteOutline).then {
         $0.cornerRadius = 5
     }

--- a/NearTalk/NearTalk/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/NearTalk/NearTalk/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -51,6 +51,7 @@ private extension DefaultLoginViewModel {
         #if DEBUG
         print(#function)
         #endif
+        
         self.loginUseCase.login(token: token)
             .subscribe { [weak self] in
                 self?.requestProfileExistence()
@@ -65,6 +66,7 @@ private extension DefaultLoginViewModel {
         #if DEBUG
         print(#function)
         #endif
+        
         self.verifyUseCase.verifyProfile()
             .subscribe { [weak self] in
                 self?.action.presentMainView?()
@@ -85,12 +87,16 @@ extension DefaultLoginViewModel: LoginViewModel {
         #if DEBUG
         print(#function)
         #endif
+        
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
-            guard let userIdentifier = appleIDCredential.identityToken, let idTokenString = String(data: userIdentifier, encoding: .utf8) else {
+            guard let userIdentifier = appleIDCredential.identityToken,
+                  let idTokenString = String(data: userIdentifier, encoding: .utf8)
+            else {
                 #if DEBUG
                 print("Failed to fetch Apple ID Token")
                 #endif
+                
                 self.loginEnableRelay.accept(true)
                 break
             }
@@ -108,6 +114,7 @@ extension DefaultLoginViewModel: LoginViewModel {
         #if DEBUG
         print(#function)
         #endif
+        
         self.loginEnableRelay.accept(false)
         let appleIDProvider: ASAuthorizationAppleIDProvider = ASAuthorizationAppleIDProvider()
         let request: ASAuthorizationAppleIDRequest = appleIDProvider.createRequest()
@@ -119,6 +126,7 @@ extension DefaultLoginViewModel: LoginViewModel {
         #if DEBUG
         print(#function)
         #endif
+        
         self.loginEnableRelay.accept(true)
     }
     
@@ -126,6 +134,7 @@ extension DefaultLoginViewModel: LoginViewModel {
         #if DEBUG
         print(#function)
         #endif
+        
         self.loginEnableRelay.accept(false)
     }
 }

--- a/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileView.swift
+++ b/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileView.swift
@@ -20,7 +20,7 @@ final class MyProfileView: UIView {
     }
     
     private let fieldStack: UIStackView = UIStackView().then {
-        $0.distribution = .fillProportionally
+        $0.distribution = .fillEqually
         $0.alignment = .fill
         $0.axis = .vertical
     }

--- a/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
+++ b/NearTalk/NearTalk/Presentation/MyProfile/View/MyProfileViewController.swift
@@ -121,6 +121,7 @@ private extension MyProfileViewController {
             .navigationBar
             .topItem?
             .backButtonDisplayMode = .minimal
+        self.navigationController?.navigationBar.tintColor = .label
 
         self.navigationItem.title = "마이 프로필"
         self.navigationItem.hidesBackButton = true

--- a/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
+++ b/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
@@ -31,8 +31,7 @@ final class RootTabBarCoordinator: Coordinator {
         let viewcontroller: RootTabBarController = rootTabBarDIContainer.resolveRootTabBarViewController()
         self.tabBarViewController = viewcontroller
         viewcontroller.viewControllers = [showMapView(), showChatRoomList(), showFriendList(), showMyProfile()]
-        viewcontroller.modalPresentationStyle = .fullScreen
-        self.navigationController?.topViewController?.present(viewcontroller, animated: false)
+        self.navigationController?.pushViewController(viewcontroller, animated: false)
         self.navigationController?.navigationBar.isHidden = true
     }
         


### PR DESCRIPTION
## 개요
로그인 로고 교체 및, UI 관련 버그 수정

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [ ] New Feature
- [x] 버그 수정
- [x] 그 외

## 설명(Description)
- [x] 로그인 시 로고를 SF Symbol -> ChatLogo로 교체
- [x] 회원 탈퇴 후, 애플 로그인->온보딩 화면 전환 시 네비게이션 바 깨져 검은색으로 가려지는 버그 픽스
- [x] 상태메세지 없을 때, 마이 프로필에서 닉네임-상태메세지 스택 배치 바뀌는 버그 픽스
- [x] 불필요한 실행문들 정리
- [x] RootTabBarViewController 화면 전환 present -> push로 변경

## Screenshot(제작 화면)
- 로고 교체 및 네비게이션 버그 픽스
https://user-images.githubusercontent.com/46563413/206227205-ea31bcf3-d07a-41ee-a7ac-7254041471b9.mov

## 주의사항 및 기타comments