### PR TITLE
[탭바] 탭바에서 스와이프 했을 때 뒤로가는 버그 수정

### DIFF
--- a/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
+++ b/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
@@ -31,8 +31,9 @@ final class RootTabBarCoordinator: Coordinator {
         let viewcontroller: RootTabBarController = rootTabBarDIContainer.resolveRootTabBarViewController()
         self.tabBarViewController = viewcontroller
         viewcontroller.viewControllers = [showMapView(), showChatRoomList(), showFriendList(), showMyProfile()]
-        self.navigationController?.pushViewController(viewcontroller, animated: false)
-        self.navigationController?.navigationBar.isHidden = true
+        let window: UIWindow? = self.navigationController?.topViewController?.view.window
+        window?.rootViewController = tabBarViewController
+        window?.makeKeyAndVisible()
     }
         
     private func showMapView() -> UIViewController {


### PR DESCRIPTION
## 개요
탭바에서 스와이프 했을 때 뒤로가는 버그 수정

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [x] 버그 수정

## 설명(Description)
- [x] 탭바에서 스와이프 했을 때 뒤로가는 버그 수정

## Screenshot(제작 화면)
### 탭바가 스와이프되는 모습(버그)
<img src="https://user-images.githubusercontent.com/41236155/206430379-931a057b-c8c4-4c95-8ecc-becdddc6bcce.gif" width="300px"/>

## 주의사항 및 기타comments
해당 PR과 관련하여 기타, comment 그리고 토의할 내용이 있으면 여기에 적어주고 아니면 여기파트를 비워두세요.