### PR TITLE
[온보딩, 프로필 수정 화면] 접근 허가된 사진만 불러오는 이미지 Picker 구현 

### DIFF
--- a/NearTalk/NearTalk.xcodeproj/project.pbxproj
+++ b/NearTalk/NearTalk.xcodeproj/project.pbxproj
@@ -208,6 +208,8 @@
 		830897DA292CC1E60090EC18 /* NecessaryProfileComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830897D9292CC1E60090EC18 /* NecessaryProfileComponent.swift */; };
 		830897DB292CC3830090EC18 /* ProfileSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830897D5292CB3760090EC18 /* ProfileSettingCoordinator.swift */; };
 		831ADB12293DA8E60070743C /* ColorSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831ADB11293DA8E60070743C /* ColorSet.swift */; };
+		831E0C5629471000006651FC /* LimitedPhotoPickerViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831E0C5529471000006651FC /* LimitedPhotoPickerViewCell.swift */; };
+		831E0C5829471010006651FC /* LimitedPhotoPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831E0C5729471010006651FC /* LimitedPhotoPickerViewController.swift */; };
 		833062262924A3BF000E786E /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833062232924A3BF000E786E /* OnboardingCoordinator.swift */; };
 		833062272924A3BF000E786E /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833062252924A3BF000E786E /* OnboardingViewModel.swift */; };
 		833062292924A3D7000E786E /* OnboardingDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833062282924A3D7000E786E /* OnboardingDIContainer.swift */; };
@@ -470,6 +472,8 @@
 		830897D7292CBD9B0090EC18 /* ProfileSettingDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingDIContainer.swift; sourceTree = "<group>"; };
 		830897D9292CC1E60090EC18 /* NecessaryProfileComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NecessaryProfileComponent.swift; sourceTree = "<group>"; };
 		831ADB11293DA8E60070743C /* ColorSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSet.swift; sourceTree = "<group>"; };
+		831E0C5529471000006651FC /* LimitedPhotoPickerViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitedPhotoPickerViewCell.swift; sourceTree = "<group>"; };
+		831E0C5729471010006651FC /* LimitedPhotoPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitedPhotoPickerViewController.swift; sourceTree = "<group>"; };
 		833062232924A3BF000E786E /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
 		833062252924A3BF000E786E /* OnboardingViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		833062282924A3D7000E786E /* OnboardingDIContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingDIContainer.swift; sourceTree = "<group>"; };
@@ -832,6 +836,8 @@
 		1660D261291DDEBE005F7B24 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				831E0C5729471010006651FC /* LimitedPhotoPickerViewController.swift */,
+				831E0C5529471000006651FC /* LimitedPhotoPickerViewCell.swift */,
 				83EE797C293F5FAA0008D859 /* UserProfileInputView.swift */,
 				83EE797E293F67D90008D859 /* UserProfileInputViewController.swift */,
 				83EE7980293FB8290008D859 /* PhotoImagePickerViewController.swift */,
@@ -1985,10 +1991,12 @@
 				7CFC7D70292374BD00A249E7 /* ProfileDetailViewController.swift in Sources */,
 				1648BAB3292389920076AC35 /* ChatRoomClusterAnnotationView.swift in Sources */,
 				833062272924A3BF000E786E /* OnboardingViewModel.swift in Sources */,
+				831E0C5829471010006651FC /* LimitedPhotoPickerViewController.swift in Sources */,
 				839D5BDD2922AD1000857FDD /* LoginViewController.swift in Sources */,
 				603EDDB32926C89000BEE65C /* RootTabBarViewModel.swift in Sources */,
 				608BD111292FD59700CB676E /* Environment.swift in Sources */,
 				6001DA88292D47320062EAD0 /* UserChatRoomTicket.swift in Sources */,
+				831E0C5629471000006651FC /* LimitedPhotoPickerViewCell.swift in Sources */,
 				83933F6E2941B24A00CC07FF /* ThemeSettingViewController.swift in Sources */,
 				7C522E1F2935BE0100331EB6 /* FetchChatRoomInfoUseCase.swift in Sources */,
 				6094B9ED29406F63008FC01B /* CDUserProfile+CoreDataClass.swift in Sources */,

--- a/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewCell.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewCell.swift
@@ -20,7 +20,7 @@ final class LimitedPhotoPickerViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        self.addViews()
+        self.addSubViews()
         self.configConstraints()
         
         self.isUserInteractionEnabled = true
@@ -63,7 +63,7 @@ extension LimitedPhotoPickerViewCell {
 }
 
 private extension LimitedPhotoPickerViewCell {
-    func addViews() {
+    func addSubViews() {
         self.addSubview(self.imageView)
         self.imageView.addSubview(self.checkMark)
     }

--- a/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewCell.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewCell.swift
@@ -1,0 +1,88 @@
+//
+//  LimitedPhotoPickerViewCell.swift
+//  NearTalk
+//
+//  Created by Preston Kim on 2022/12/11.
+//
+
+import Photos
+import SnapKit
+import UIKit
+
+final class LimitedPhotoPickerViewCell: UICollectionViewCell {
+    static let identifer: String = String(describing: UICollectionViewCell.self)
+    
+    private let imageView: UIImageView = UIImageView()
+    private let checkMark: UIImageView = UIImageView(image: UIImage(systemName: "checkmark.circle.fill")).then {
+        $0.tintColor = .secondaryColor
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.addViews()
+        self.configConstraints()
+        
+        self.isUserInteractionEnabled = true
+        self.checkMark.isHidden = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.imageView.image = nil
+        self.isSelected = false
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                self.layer.borderColor = UIColor.secondaryColor?.cgColor
+                self.layer.borderWidth = 2.0
+            } else {
+                self.layer.borderWidth = 0.0
+                self.layer.borderColor = nil
+            }
+            self.checkMark.isHidden = !isSelected
+        }
+    }
+}
+
+extension LimitedPhotoPickerViewCell {
+    var image: UIImage? {
+        get {
+            self.imageView.image
+        } set {
+            self.imageView.image = newValue ?? UIImage(systemName: "photo")
+        }
+    }
+}
+
+private extension LimitedPhotoPickerViewCell {
+    func addViews() {
+        self.addSubview(self.imageView)
+        self.imageView.addSubview(self.checkMark)
+    }
+    
+    func configConstraints() {
+        self.configImageViewConstraints()
+        self.configCheckMarkConstraints()
+    }
+    
+    func configImageViewConstraints() {
+        self.imageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    func configCheckMarkConstraints() {
+        self.checkMark.snp.makeConstraints { make in
+            make.bottom.trailing.equalToSuperview()
+            make.width.height.equalTo(self.snp.width).dividedBy(4)
+        }
+    }
+}

--- a/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewController.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewController.swift
@@ -1,0 +1,216 @@
+//
+//  LimitedPhotoPickerViewController.swift
+//  NearTalk
+//
+//  Created by Preston Kim on 2022/12/11.
+//
+
+import Photos
+import PhotosUI
+import RxRelay
+import RxSwift
+import SnapKit
+import UIKit
+
+enum PhotoSection: Hashable, Sendable {
+    case main
+}
+
+final class LimitedPhotoPickerViewController: UIViewController {
+    private lazy var contentView: UICollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: self.makeViewLayout()).then {
+        $0.backgroundColor = .primaryBackground
+        $0.register(
+            LimitedPhotoPickerViewCell.self,
+            forCellWithReuseIdentifier: LimitedPhotoPickerViewCell.identifer)
+    }
+
+    private lazy var dataSouce: UICollectionViewDiffableDataSource<PhotoSection, PHAsset> = UICollectionViewDiffableDataSource(
+        collectionView: self.contentView) { collectionView, indexPath, itemIdentifier in
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: LimitedPhotoPickerViewCell.identifer,
+            for: indexPath) as? LimitedPhotoPickerViewCell
+        else {
+            return UICollectionViewCell()
+        }
+        
+        PHImageManager.default().requestImage(
+            for: itemIdentifier,
+            targetSize: .init(width: 320, height: 320),
+            contentMode: .aspectFit,
+            options: nil) { image, _ in
+            cell.image = image
+        }
+
+        return cell
+    }
+    
+    private let disposeBag: DisposeBag = .init()
+    private var fetchResults: PHFetchResult<PHAsset>?
+    private let selectedIndex: BehaviorRelay<IndexPath?> = BehaviorRelay(value: nil)
+    
+    var itemSelectedEvent: ((_ image: UIImage?) -> Void)?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        PHPhotoLibrary.shared().register(self)
+        self.initDataSource()
+        self.contentView.delegate = self
+        self.configureNavigation()
+        self.addSubViews()
+    }
+    
+    deinit {
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
+    }
+}
+
+extension LimitedPhotoPickerViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let nextCell = collectionView.cellForItem(at: indexPath) as? LimitedPhotoPickerViewCell
+        else {
+            return
+        }
+        
+        if let prevSelectedIndex = self.selectedIndex.value,
+           let prevCell = collectionView.cellForItem(at: prevSelectedIndex) {
+            prevCell.isSelected = false
+        }
+        
+        nextCell.isSelected = true
+        self.selectedIndex.accept(indexPath)
+    }
+}
+
+extension LimitedPhotoPickerViewController {
+    func makeViewLayout() -> UICollectionViewCompositionalLayout {
+        let itemSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.25),
+            heightDimension: .fractionalWidth(0.25))
+        let item: NSCollectionLayoutItem = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalWidth(0.25))
+        let group: NSCollectionLayoutGroup = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item])
+
+        let section: NSCollectionLayoutSection = NSCollectionLayoutSection(group: group)
+        let layout: UICollectionViewCompositionalLayout = UICollectionViewCompositionalLayout(section: section)
+
+        return layout
+    }
+}
+
+extension LimitedPhotoPickerViewController: PHPhotoLibraryChangeObserver {
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        guard let fetchResults = self.fetchResults
+        else {
+            return
+        }
+        
+        if let changes = changeInstance.changeDetails(for: fetchResults) {
+            var snapShot = self.dataSouce.snapshot()
+            snapShot.deleteAllItems()
+            snapShot.appendSections([.main])
+            changes.fetchResultAfterChanges.enumerateObjects { asset, _, _ in
+                snapShot.appendItems([asset], toSection: .main)
+            }
+            self.dataSouce.apply(snapShot, animatingDifferences: true)
+            self.selectedIndex.accept(nil)
+        }
+    }
+}
+
+private extension LimitedPhotoPickerViewController {
+    func addSubViews() {
+        self.view.addSubview(self.contentView)
+        self.contentView.snp.makeConstraints { make in
+            make.edges.equalTo(self.view.safeAreaLayoutGuide)
+        }
+    }
+    
+    func initDataSource() {
+        var snapShot = NSDiffableDataSourceSnapshot<PhotoSection, PHAsset>()
+        let fetchResults = PHAsset.fetchAssets(with: .image, options: nil)
+        self.fetchResults = fetchResults
+        snapShot.appendSections([.main])
+        fetchResults.enumerateObjects { asset, _, _ in
+            snapShot.appendItems([asset], toSection: .main)
+        }
+        self.dataSouce.apply(snapShot, animatingDifferences: true)
+    }
+    
+    func configureNavigation() {
+        self.configureNavigationItemUI()
+        self.bindNavigationButtonEvents()
+    }
+    
+    func bindNavigationButtonEvents() {
+        self.bindCancelButtonEvent()
+        self.bindSelectButtonEvent()
+    }
+    
+    func bindCancelButtonEvent() {
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "취소", style: .done, target: nil, action: nil)
+        self.navigationItem.rightBarButtonItem?.rx
+            .tap
+            .asSignal()
+            .emit(onNext: { [weak self] _ in
+                self?.dismiss(animated: true)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func bindSelectButtonEvent() {
+        let selectButton: UIBarButtonItem = UIBarButtonItem(title: "선택", style: .plain, target: nil, action: nil)
+        self.navigationItem.leftBarButtonItem = selectButton
+        self.navigationItem.leftBarButtonItem?.rx
+            .tap
+            .asSignal()
+            .emit(onNext: { [weak self] _ in
+                guard let index = self?.selectedIndex.value,
+                      let cell = self?.contentView.cellForItem(at: index) as? LimitedPhotoPickerViewCell,
+                      let image = cell.image
+                else {
+                    self?.itemSelectedEvent?(nil)
+                    self?.dismiss(animated: true)
+                    return
+                }
+                self?.itemSelectedEvent?(image)
+                self?.dismiss(animated: true)
+            })
+            .disposed(by: self.disposeBag)
+        
+        self.selectedIndex.asDriver()
+            .map {
+                guard let indexPath = $0,
+                      self.contentView.cellForItem(at: indexPath) as? LimitedPhotoPickerViewCell != nil
+                else {
+                    return false
+                }
+                return true
+            }
+            .drive(selectButton.rx.isEnabled)
+            .disposed(by: self.disposeBag)
+    }
+    
+    func configureNavigationItemUI() {
+        let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .systemGray6
+        
+        self.contentView.contentInsetAdjustmentBehavior = .never
+        self.navigationItem.title = "사진 선택"
+        self.navigationController?.navigationBar.isHidden = false
+        
+        self.navigationItem.compactAppearance = appearance
+        self.navigationItem.standardAppearance = appearance
+        self.navigationItem.scrollEdgeAppearance = appearance
+        self.navigationItem.compactScrollEdgeAppearance = appearance
+        self.navigationController?.navigationBar.tintColor = .label
+    }
+}

--- a/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewController.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewController.swift
@@ -84,27 +84,6 @@ extension LimitedPhotoPickerViewController: UICollectionViewDelegate {
     }
 }
 
-extension LimitedPhotoPickerViewController {
-    func makeViewLayout() -> UICollectionViewCompositionalLayout {
-        let itemSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(0.25),
-            heightDimension: .fractionalWidth(0.25))
-        let item: NSCollectionLayoutItem = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        let groupSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalWidth(0.25))
-        let group: NSCollectionLayoutGroup = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitems: [item])
-
-        let section: NSCollectionLayoutSection = NSCollectionLayoutSection(group: group)
-        let layout: UICollectionViewCompositionalLayout = UICollectionViewCompositionalLayout(section: section)
-
-        return layout
-    }
-}
-
 extension LimitedPhotoPickerViewController: PHPhotoLibraryChangeObserver {
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         guard let fetchResults = self.fetchResults
@@ -212,5 +191,24 @@ private extension LimitedPhotoPickerViewController {
         self.navigationItem.scrollEdgeAppearance = appearance
         self.navigationItem.compactScrollEdgeAppearance = appearance
         self.navigationController?.navigationBar.tintColor = .label
+    }
+    
+    func makeViewLayout() -> UICollectionViewCompositionalLayout {
+        let itemSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.25),
+            heightDimension: .fractionalWidth(0.25))
+        let item: NSCollectionLayoutItem = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalWidth(0.25))
+        let group: NSCollectionLayoutGroup = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item])
+
+        let section: NSCollectionLayoutSection = NSCollectionLayoutSection(group: group)
+        let layout: UICollectionViewCompositionalLayout = UICollectionViewCompositionalLayout(section: section)
+
+        return layout
     }
 }

--- a/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewController.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/LimitedPhotoPickerViewController.swift
@@ -31,9 +31,7 @@ final class LimitedPhotoPickerViewController: UIViewController {
         guard let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: LimitedPhotoPickerViewCell.identifer,
             for: indexPath) as? LimitedPhotoPickerViewCell
-        else {
-            return UICollectionViewCell()
-        }
+        else { return UICollectionViewCell() }
         
         PHImageManager.default().requestImage(
             for: itemIdentifier,
@@ -70,14 +68,10 @@ final class LimitedPhotoPickerViewController: UIViewController {
 extension LimitedPhotoPickerViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let nextCell = collectionView.cellForItem(at: indexPath) as? LimitedPhotoPickerViewCell
-        else {
-            return
-        }
+        else { return }
         
         if let prevSelectedIndex = self.selectedIndex.value,
-           let prevCell = collectionView.cellForItem(at: prevSelectedIndex) {
-            prevCell.isSelected = false
-        }
+           let prevCell = collectionView.cellForItem(at: prevSelectedIndex) { prevCell.isSelected = false }
         
         nextCell.isSelected = true
         self.selectedIndex.accept(indexPath)
@@ -87,9 +81,7 @@ extension LimitedPhotoPickerViewController: UICollectionViewDelegate {
 extension LimitedPhotoPickerViewController: PHPhotoLibraryChangeObserver {
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         guard let fetchResults = self.fetchResults
-        else {
-            return
-        }
+        else { return }
         
         if let changes = changeInstance.changeDetails(for: fetchResults) {
             var snapShot = self.dataSouce.snapshot()
@@ -135,8 +127,7 @@ private extension LimitedPhotoPickerViewController {
     
     func bindCancelButtonEvent() {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "취소", style: .done, target: nil, action: nil)
-        self.navigationItem.rightBarButtonItem?.rx
-            .tap
+        self.navigationItem.rightBarButtonItem?.rx.tap
             .asSignal()
             .emit(onNext: { [weak self] _ in
                 self?.dismiss(animated: true)
@@ -147,8 +138,7 @@ private extension LimitedPhotoPickerViewController {
     func bindSelectButtonEvent() {
         let selectButton: UIBarButtonItem = UIBarButtonItem(title: "선택", style: .plain, target: nil, action: nil)
         self.navigationItem.leftBarButtonItem = selectButton
-        self.navigationItem.leftBarButtonItem?.rx
-            .tap
+        self.navigationItem.leftBarButtonItem?.rx.tap
             .asSignal()
             .emit(onNext: { [weak self] _ in
                 guard let index = self?.selectedIndex.value,
@@ -164,13 +154,13 @@ private extension LimitedPhotoPickerViewController {
             })
             .disposed(by: self.disposeBag)
         
-        self.selectedIndex.asDriver()
+        self.selectedIndex
+            .asDriver()
             .map {
                 guard let indexPath = $0,
                       self.contentView.cellForItem(at: indexPath) as? LimitedPhotoPickerViewCell != nil
-                else {
-                    return false
-                }
+                else { return false }
+
                 return true
             }
             .drive(selectButton.rx.isEnabled)
@@ -180,7 +170,7 @@ private extension LimitedPhotoPickerViewController {
     func configureNavigationItemUI() {
         let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = .systemGray6
+        appearance.backgroundColor = .secondaryBackground
         
         self.contentView.contentInsetAdjustmentBehavior = .never
         self.navigationItem.title = "사진 선택"

--- a/NearTalk/NearTalk/Infrastructure/Utils/PhotoImagePickerViewController.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/PhotoImagePickerViewController.swift
@@ -36,10 +36,8 @@ extension PhotoImagePickerViewController {
     }
     
     private func goAuthorizationSettingPage() {
-        guard let appName: String = Bundle.main.infoDictionary!["CFBundleIdentifier"] as? String
-        else {
-            return
-        }
+        guard let appName: String = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String
+        else { return }
         
         let message: String = "\(appName)이(가) 앨범 접근 허용되어 있지않습니다. \r\n 설정화면으로 가시겠습니까?"
         let alert: UIAlertController = UIAlertController(title: "설정", message: message, preferredStyle: .alert)


### PR DESCRIPTION
## 개요
아이폰 설정 앱에서 선택한 사진에 해당하는 사진만 불러오는 이미지 Picker 구현 

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [x] New Feature
- [ ] 버그 수정
- [ ] 그 외

## 설명(Description)
- [x] 허가된 사진만 불러오는 LimitedPhotoPickerViewController 추가
- [x] PhotoImagePickerViewController에서 present 시 UIImageViewController -> LimitedPhotoPickerViewController로 변경

## Screenshot(제작 화면)
- 데모

https://user-images.githubusercontent.com/46563413/207029144-81ee58c5-a187-4d33-b4cc-82c67536058a.mov

## 주의사항 및 기타comments
- 동영상은 접근 허가를 주어도, 피커에 불러오지 않는게 정상입니다. 서버에는 현재 영상 저장이 안되기 때문에, 아예 사진만 프로필로 사용할 수 있습니다. 그래서, 선택한 사진들에서 동영상을 선택해도, 피커에 아예 안불러오기 때문에 안보입니다. 즉, 동영상만 접근 허가를 하게 되면, 피커가 비어있게 됩니다.