### PR TITLE
[채팅방, 탭바] 채팅방 탈퇴 기능 구현 및 탭바 UI 버그 수정

### DIFF
--- a/NearTalk/NearTalk.xcodeproj/project.pbxproj
+++ b/NearTalk/NearTalk.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		833062292924A3D7000E786E /* OnboardingDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833062282924A3D7000E786E /* OnboardingDIContainer.swift */; };
 		8330622B2924A3E2000E786E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8330622F2924A402000E786E /* String+Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8330622E2924A402000E786E /* String+Regex.swift */; };
+		833D035629496E720029DF76 /* DropChatRoomUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833D035529496E720029DF76 /* DropChatRoomUseCase.swift */; };
 		83649765292D33B60002DDE5 /* AppSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E7BBC62922AFED007C390A /* AppSettingViewController.swift */; };
 		83649766292D33B90002DDE5 /* AppSettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E7BBC52922AFED007C390A /* AppSettingTableViewCell.swift */; };
 		83649769292D393C0002DDE5 /* AppSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83649768292D393C0002DDE5 /* AppSettingViewModel.swift */; };
@@ -478,6 +479,7 @@
 		833062252924A3BF000E786E /* OnboardingViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		833062282924A3D7000E786E /* OnboardingDIContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingDIContainer.swift; sourceTree = "<group>"; };
 		8330622E2924A402000E786E /* String+Regex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Regex.swift"; sourceTree = "<group>"; };
+		833D035529496E720029DF76 /* DropChatRoomUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropChatRoomUseCase.swift; sourceTree = "<group>"; };
 		83649768292D393C0002DDE5 /* AppSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingViewModel.swift; sourceTree = "<group>"; };
 		8364976C292D3C920002DDE5 /* DummyProfileRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyProfileRepository.swift; sourceTree = "<group>"; };
 		83649770292DE1B50002DDE5 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -1235,6 +1237,7 @@
 				7C522E1E2935BE0100331EB6 /* FetchChatRoomInfoUseCase.swift */,
 				7C749850292F706F00FADA94 /* MessagingUseCase.swift */,
 				7C8197432939E79700A7DD8F /* EnterChatRoomUseCase.swift */,
+				833D035529496E720029DF76 /* DropChatRoomUseCase.swift */,
 				7C254DA9292DB22B004D4CEC /* Coordinator */,
 				7C254DA8292DB21E004D4CEC /* ViewModel */,
 				7C254DA7292DB217004D4CEC /* View */,
@@ -1917,6 +1920,7 @@
 				830897DA292CC1E60090EC18 /* NecessaryProfileComponent.swift in Sources */,
 				7CA4EA38292BA65000D8C757 /* FetchProfileUseCase.swift in Sources */,
 				6094B9EE29406F63008FC01B /* CDChatRoom+CoreDataProperties.swift in Sources */,
+				833D035629496E720029DF76 /* DropChatRoomUseCase.swift in Sources */,
 				1648BAAD292385CD0076AC35 /* ChatRoomAnnotation.swift in Sources */,
 				162B1B682933E036004724D9 /* RxMapViewReactiveDataSource.swift in Sources */,
 				16988882292F550500CEC7B9 /* AccessibleChatRoomsRepository.swift in Sources */,

--- a/NearTalk/NearTalk/Application/DIContainer/ChatDIContainer.swift
+++ b/NearTalk/NearTalk/Application/DIContainer/ChatDIContainer.swift
@@ -69,6 +69,10 @@ final class ChatDIContainer {
         )
     }
     
+    func makeDropChatRoomUseCase() -> any DropChatRoomUseCase {
+        return DefaultDropChatRoomUseCase(chatRoomListRepository: self.makeChatRoomListRepository(), profileRepository: self.makeProfileRepository(), userDefaultsRepository: self.makeUserDefaultsRepository())
+    }
+    
     // MARK: - Repositories
     
     func makeUserDefaultsRepository() -> UserDefaultsRepository {
@@ -115,7 +119,8 @@ final class ChatDIContainer {
             userDefaultUseCase: self.makeUserDefaultUseCase(),
             fetchProfileUseCase: self.makeFetchProfileUseCase(),
             messagingUseCase: self.makeMessggingUseCase(),
-            enterChatRoomUseCase: self.makeEnterChatRoomUseCase())
+            enterChatRoomUseCase: self.makeEnterChatRoomUseCase(),
+            dropChatRoomUseCase: self.makeDropChatRoomUseCase())
     }
     // MARK: - Coordinator
     func makeChatCoordinator(navigationController: UINavigationController) -> ChatCoordinator {

--- a/NearTalk/NearTalk/Data/Repositories/ChatRoomListRepository.swift
+++ b/NearTalk/NearTalk/Data/Repositories/ChatRoomListRepository.swift
@@ -24,4 +24,5 @@ protocol ChatRoomListRepository {
     func updateUserChatRoomTicket(_ ticket: UserChatRoomTicket) -> Single<UserChatRoomTicket>
     func observeUserChatRoomTicketList() -> Observable<[UserChatRoomTicket]>
     func dropUserFromChatRooms() -> Completable
+    func dropUserFromChatRoom(_ userUUID: String, _ roomID: String) -> Completable
 }

--- a/NearTalk/NearTalk/Data/Repositories/DefaultChatRoomListRepository.swift
+++ b/NearTalk/NearTalk/Data/Repositories/DefaultChatRoomListRepository.swift
@@ -28,7 +28,7 @@ final class DefaultChatRoomListRepository {
     }
 }
 
-extension DefaultChatRoomListRepository: ChatRoomListRepository {
+extension DefaultChatRoomListRepository: ChatRoomListRepository {    
     func dropUserFromChatRoom(_ userUUID: String, _ roomID: String) -> Completable {
         self.fetchChatRoomInfo(roomID)
             .flatMapCompletable { room in
@@ -40,12 +40,25 @@ extension DefaultChatRoomListRepository: ChatRoomListRepository {
     func dropUserFromChatRoom(chatRoom: ChatRoom, uuid: String) -> Completable {
         var updatingChatRoom: ChatRoom = chatRoom
         updatingChatRoom.userList = chatRoom.userList?.filter { $0 != uuid }
-        return self.firestoreService
-            .update(updatedData: updatingChatRoom, dataKey: .chatRoom)
-            .asCompletable()
-            .andThen(self.databaseService
-                .updateChatRoom(updatingChatRoom)
-                .asCompletable())
+        guard let nextUserList = updatingChatRoom.userList, let roomID = updatingChatRoom.uuid else {
+            return Completable.error(ChatRoomListRepositoryError.corruptedChatRoom)
+        }
+        
+        if nextUserList.isEmpty {
+            return self.firestoreService
+                .delete(data: chatRoom, dataKey: .chatRoom)
+                .andThen(self.databaseService
+                    .deleteChatRoom(roomID))
+                .andThen(self.databaseService
+                    .deleteChatMessages(roomID))
+        } else {
+            return self.firestoreService
+                .update(updatedData: updatingChatRoom, dataKey: .chatRoom)
+                .asCompletable()
+                .andThen(self.databaseService
+                    .updateChatRoom(updatingChatRoom)
+                    .asCompletable())
+        }
     }
     
     func dropUserFromChatRooms() -> Completable {
@@ -170,4 +183,5 @@ extension DefaultChatRoomListRepository: ChatRoomListRepository {
 enum ChatRoomListRepositoryError: Error {
     case failedToFetch
     case failedToCrate
+    case corruptedChatRoom
 }

--- a/NearTalk/NearTalk/Data/Repositories/DefaultChatRoomListRepository.swift
+++ b/NearTalk/NearTalk/Data/Repositories/DefaultChatRoomListRepository.swift
@@ -33,6 +33,7 @@ extension DefaultChatRoomListRepository: ChatRoomListRepository {
         self.fetchChatRoomInfo(roomID)
             .flatMapCompletable { room in
                 self.dropUserFromChatRoom(chatRoom: room, uuid: userUUID)
+                    .andThen(self.databaseService.deleteUserTicket(userUUID, roomID))
             }
     }
     

--- a/NearTalk/NearTalk/Data/Repositories/DefaultChatRoomListRepository.swift
+++ b/NearTalk/NearTalk/Data/Repositories/DefaultChatRoomListRepository.swift
@@ -29,6 +29,12 @@ final class DefaultChatRoomListRepository {
 }
 
 extension DefaultChatRoomListRepository: ChatRoomListRepository {
+    func dropUserFromChatRoom(_ userUUID: String, _ roomID: String) -> Completable {
+        self.fetchChatRoomInfo(roomID)
+            .flatMapCompletable { room in
+                self.dropUserFromChatRoom(chatRoom: room, uuid: userUUID)
+            }
+    }
     
     func dropUserFromChatRoom(chatRoom: ChatRoom, uuid: String) -> Completable {
         var updatingChatRoom: ChatRoom = chatRoom

--- a/NearTalk/NearTalk/Infrastructure/Network/RealTimeDatabaseService.swift
+++ b/NearTalk/NearTalk/Infrastructure/Network/RealTimeDatabaseService.swift
@@ -30,6 +30,7 @@ protocol RealTimeDatabaseService {
     func fetchUserChatRoomTicketList(_ userID: String) -> Single<[UserChatRoomTicket]>
     func observeUserChatRoomTicketList(_ userID: String) -> Observable<[UserChatRoomTicket]>
     func deleteUserTicketList(_ userID: String) -> Completable
+    func deleteUserTicket(_ userID: String, _ chatRoomID: String) -> Completable
 }
 
 // swiftlint:disable: type_body_length
@@ -363,6 +364,25 @@ final class DefaultRealTimeDatabaseService: RealTimeDatabaseService {
             self?.ref
                 .child(FirebaseKey.RealtimeDB.users.rawValue)
                 .child(userID)
+                .removeValue(completionBlock: { error, _ in
+                    if let error = error {
+                        completable(.error(error))
+                    } else {
+                        completable(.completed)
+                    }
+                })
+            return Disposables.create()
+        }
+    }
+    
+    func deleteUserTicket(_ userID: String, _ chatRoomID: String) -> Completable {
+        Completable.create { [weak self] completable in
+            self?.ref
+                .child(FirebaseKey.RealtimeDB.users.rawValue)
+                .child(userID)
+                .child(FirebaseKey.RealtimeDB.userChatRoomTickets.rawValue)
+                .queryEqual(toValue: chatRoomID, childKey: "roomID")
+                .ref
                 .removeValue(completionBlock: { error, _ in
                     if let error = error {
                         completable(.error(error))

--- a/NearTalk/NearTalk/Infrastructure/Network/RealTimeDatabaseService.swift
+++ b/NearTalk/NearTalk/Infrastructure/Network/RealTimeDatabaseService.swift
@@ -15,6 +15,7 @@ protocol RealTimeDatabaseService {
     func fetchSingleMessage(messageID: String, roomID: String) -> Single<ChatMessage>
     func fetchMessages(date: Date, pageCount: Int, roomID: String) -> Single<[ChatMessage]>
     func observeNewMessage(_ chatRoomID: String) -> Observable<ChatMessage>
+    func deleteChatMessages(_ chatRoomID: String) -> Completable
     
     // MARK: 채팅방 정보
     func createChatRoom(_ chatRoom: ChatRoom) -> Single<ChatRoom>
@@ -22,6 +23,7 @@ protocol RealTimeDatabaseService {
     func increaseChatRoomMessageCount(_ chatRoomID: String) -> Completable
     func fetchChatRoomInfo(_ chatRoomID: String) -> Single<ChatRoom>
     func observeChatRoomInfo(_ chatRoomID: String) -> Observable<ChatRoom>
+    func deleteChatRoom(_ chatRoomID: String) -> Completable
     
     // MARK: 유저-채팅방 티켓 정보
     func createUserChatRoomTicket(_ ticket: UserChatRoomTicket) -> Single<UserChatRoomTicket>
@@ -403,6 +405,38 @@ final class DefaultRealTimeDatabaseService: RealTimeDatabaseService {
                 .child(FirebaseKey.RealtimeDB.users.rawValue)
                 .child(userID)
                 .child(FirebaseKey.RealtimeDB.userChatRoomTickets.rawValue)
+                .child(chatRoomID)
+                .removeValue(completionBlock: { error, _ in
+                    if let error = error {
+                        completable(.error(error))
+                    } else {
+                        completable(.completed)
+                    }
+                })
+            return Disposables.create()
+        }
+    }
+    
+    func deleteChatRoom(_ chatRoomID: String) -> Completable {
+        Completable.create { [weak self] completable in
+            self?.ref
+                .child(FirebaseKey.RealtimeDB.chatRooms.rawValue)
+                .child(chatRoomID)
+                .removeValue(completionBlock: { error, _ in
+                    if let error = error {
+                        completable(.error(error))
+                    } else {
+                        completable(.completed)
+                    }
+                })
+            return Disposables.create()
+        }
+    }
+    
+    func deleteChatMessages(_ chatRoomID: String) -> Completable {
+        Completable.create { [weak self] completable in
+            self?.ref
+                .child(FirebaseKey.RealtimeDB.chatMessages.rawValue)
                 .child(chatRoomID)
                 .removeValue(completionBlock: { error, _ in
                     if let error = error {

--- a/NearTalk/NearTalk/Infrastructure/Network/RealTimeDatabaseService.swift
+++ b/NearTalk/NearTalk/Infrastructure/Network/RealTimeDatabaseService.swift
@@ -403,8 +403,7 @@ final class DefaultRealTimeDatabaseService: RealTimeDatabaseService {
                 .child(FirebaseKey.RealtimeDB.users.rawValue)
                 .child(userID)
                 .child(FirebaseKey.RealtimeDB.userChatRoomTickets.rawValue)
-                .queryEqual(toValue: chatRoomID, childKey: "roomID")
-                .ref
+                .child(chatRoomID)
                 .removeValue(completionBlock: { error, _ in
                     if let error = error {
                         completable(.error(error))

--- a/NearTalk/NearTalk/Presentation/Chat/DropChatRoomUseCase.swift
+++ b/NearTalk/NearTalk/Presentation/Chat/DropChatRoomUseCase.swift
@@ -1,0 +1,47 @@
+//
+//  DropChatRoomUseCase.swift
+//  NearTalk
+//
+//  Created by Preston Kim on 2022/12/14.
+//
+
+import RxSwift
+
+protocol DropChatRoomUseCase {
+    /// 방 탈퇴
+    func execute(_ userID: String, _ roomID: String) -> Completable
+}
+
+final class DefaultDropChatRoomUseCase: DropChatRoomUseCase {
+    
+    private let chatRoomListRepository: any ChatRoomListRepository
+    private let profileRepository: any ProfileRepository
+    private let userDefaultsRepository: any UserDefaultsRepository
+    
+    init(
+        chatRoomListRepository: any ChatRoomListRepository,
+        profileRepository: any ProfileRepository,
+        userDefaultsRepository: any UserDefaultsRepository
+    ) {
+        self.chatRoomListRepository = chatRoomListRepository
+        self.profileRepository = profileRepository
+        self.userDefaultsRepository = userDefaultsRepository
+    }
+    
+    /// 방 탈퇴
+    func execute(_ userID: String, _ roomID: String) -> Completable {
+        self.profileRepository.fetchMyProfile()
+            .flatMapCompletable { profile in
+                var copy: UserProfile = profile
+                copy.chatRooms = profile.chatRooms?.filter { $0 != roomID }
+                self.userDefaultsRepository.saveUserProfile(copy)
+                return self.profileRepository.updateMyProfile(copy)
+                    .asCompletable()
+                    .andThen(self.chatRoomListRepository.dropUserFromChatRoom(userID, roomID))
+            }
+    }
+}
+
+enum DropChatRoomUseCaseError: Error {
+    case faildToExit
+}

--- a/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
+++ b/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
@@ -36,7 +36,7 @@ final class RootTabBarCoordinator: Coordinator {
         }
         
         var inactivatedImage: UIImage? {
-            guard let color: UIColor = .primaryColor
+            guard let color: UIColor = .label
             else {
                 return nil
             }
@@ -54,7 +54,7 @@ final class RootTabBarCoordinator: Coordinator {
         }
         
         var activatedImage: UIImage? {
-            guard let color: UIColor = .secondaryColor
+            guard let color: UIColor = .label
             else {
                 return nil
             }

--- a/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
+++ b/NearTalk/NearTalk/Presentation/TabBar/Coordinator/RootTabBarCoordinator.swift
@@ -45,9 +45,9 @@ final class RootTabBarCoordinator: Coordinator {
             case .mapView:
                 return UIImage(systemName: "map")?.withTintColor(color)
             case .chatRoomList:
-                return UIImage(systemName: "message.badge")?.withTintColor(color)
+                return UIImage(systemName: "message")?.withTintColor(color)
             case .friendList:
-                return UIImage(systemName: "person.line.dotted.person")?.withTintColor(color)
+                return UIImage(systemName: "person.3")?.withTintColor(color)
             case .myProfile:
                 return UIImage(systemName: "person.text.rectangle")?.withTintColor(color)
             }
@@ -63,9 +63,9 @@ final class RootTabBarCoordinator: Coordinator {
             case .mapView:
                 return UIImage(systemName: "map.fill")?.withTintColor(color)
             case .chatRoomList:
-                return UIImage(systemName: "message.badge.filled.fill")?.withTintColor(color)
+                return UIImage(systemName: "message.fill")?.withTintColor(color)
             case .friendList:
-                return UIImage(systemName: "person.line.dotted.person.fill")?.withTintColor(color)
+                return UIImage(systemName: "person.3.fill")?.withTintColor(color)
             case .myProfile:
                 return UIImage(systemName: "person.text.rectangle.fill")?.withTintColor(color)
             }


### PR DESCRIPTION
## 개요
resolved #192
탭바 UI 아이콘 버그 수정

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [x] New Feature
- [x] 버그 수정
- [x] 그 외

## 설명(Description)
- [x] RootTabBar 아이템 아이콘을 색 검정 테마로 변경 및 iOS 15버전에 맞는 아이콘으로 변경
- [x] 채팅방 탈퇴 시, DB의 ChatRooms의 userList에서 탈퇴하는 방에서 계정 UUID 제거
- [x] 채팅방 탈퇴 시, DB의 UserProfile의 roomLists에서 탈퇴하는 방 UUID 제거
- [x] 채팅방 탈퇴 시, Realtime DB의 users의 탈퇴하는 방에 해당하는 티켓 삭제
- [x] 채팅방 탈퇴 시, Realtime DB의 ChatRooms의 userLists에서 탈퇴하는 계정의 UUID 제거
- [x] 채팅방 화면 우측 상단 네비게이션 바에 방 탈퇴 버튼 추가 및 동작 구현
- [x] 채팅방 탈퇴 시, 방이 비어지면, 자동으로 DB에서 방 삭제  

## Screenshot(제작 화면)

## 주의사항 및 기타comments
