### PR TITLE
[메인지도] 메인 지도에서 말풍선 SF Symbol을 iOS 15 기기에 호환되는 Symbol로 변경

### DIFF
--- a/NearTalk/NearTalk/Presentation/MainMap/View/MainMapViewController.swift
+++ b/NearTalk/NearTalk/Presentation/MainMap/View/MainMapViewController.swift
@@ -72,10 +72,10 @@ final class MainMapViewController: UIViewController {
         }
         
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 40)
-        let normalImage = UIImage(systemName: "message.badge.circle")?
+        let normalImage = UIImage(systemName: "message.circle")?
             .withTintColor(normalColor, renderingMode: .alwaysOriginal)
             .withConfiguration(imageConfig)
-        let highlightImage = UIImage(systemName: "message.badge.circle")?
+        let highlightImage = UIImage(systemName: "message.circle")?
             .withTintColor(highlightedColor, renderingMode: .alwaysOriginal)
             .withConfiguration(imageConfig)
         


### PR DESCRIPTION
## 개요

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [ ] New Feature
- [x] 버그 수정
- [ ] 그 외

## 설명(Description)
- [x] message.badge.circle -> message.circle로 수정
- [ ] 이거 수정했어요 2
- [ ] 이거 삭제했어요 3

## Screenshot(제작 화면)

## 주의사항 및 기타comments