### PR TITLE
[프로필 수정, 온보딩] 색상 버그 픽스

### DIFF
--- a/NearTalk/NearTalk/Infrastructure/Utils/UserProfileInputView.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/UserProfileInputView.swift
@@ -56,6 +56,8 @@ class UserProfileInputView: UIView {
     }
 
     private let nicknameField: UITextField = UITextField().then {
+        $0.borderStyle = .none
+        $0.backgroundColor = .secondaryBackground
         $0.autocorrectionType = .no
         $0.placeholder = "닉네임"
         $0.layer.cornerRadius = 5.0
@@ -68,6 +70,7 @@ class UserProfileInputView: UIView {
     private let messageField: UITextView = UITextView().then {
         $0.returnKeyType = .done
         $0.isScrollEnabled = false
+        $0.backgroundColor = .secondaryBackground
         $0.sizeToFit()
         $0.textContainer.size = $0.contentSize
         $0.textContainer.maximumNumberOfLines = 2

--- a/NearTalk/NearTalk/Infrastructure/Utils/UserProfileInputViewController.swift
+++ b/NearTalk/NearTalk/Infrastructure/Utils/UserProfileInputViewController.swift
@@ -79,7 +79,7 @@ class UserProfileInputViewController: PhotoImagePickerViewController {
     
     func configureRootViewConstraint() {
         self.rootView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.edges.equalTo(self.scrollView.safeAreaLayoutGuide)
             make.width.height.equalToSuperview()
         }
     }


### PR DESCRIPTION
## 개요

해당하는 부분에 체크해주세요(x 표시 하면 됩니다)
- [ ] New Feature
- [x] 버그 수정
- [ ] 그 외

## 설명(Description)
- [x] 프로필 수정으로 넘어갈 때, 탭바 색 혼자 검정색 되는 버그 픽스
- [x] 닉네임, 상태메세지 텍스트 필드, 뷰 배경색 통일
- [ ] 이거 삭제했어요 3

## Screenshot(제작 화면)

## 주의사항 및 기타comments